### PR TITLE
Adds OpenAI compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 vendor/
 *.wav
 *.DS_store
+.venv
+venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +98,73 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "backtrace"
@@ -562,7 +640,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -581,9 +659,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
 
 [[package]]
 name = "heck"
@@ -647,6 +741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +759,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -859,12 +960,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -921,16 +1032,22 @@ dependencies = [
 name = "koko"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "clap",
  "espeak-rs",
  "hound",
+ "hyper",
  "indicatif",
  "lazy_static",
  "ndarray",
  "ort",
  "regex",
  "reqwest",
+ "serde",
  "serde_json",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http",
 ]
 
 [[package]]
@@ -985,10 +1102,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -1198,10 +1331,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1237,6 +1413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1447,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1344,7 +1559,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tower",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1435,6 +1650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1669,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1505,6 +1732,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1769,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1690,9 +1936,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1730,6 +1990,27 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "hdrhistogram",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -1741,6 +2022,24 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1761,6 +2060,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2163,6 +2463,27 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,19 @@ serde_json = "1.0.135"
 espeak-rs = "0.1.9"
 clap = { version = "4.5.26", features = ["derive"] }
 
+# ONNX Runtime dependencies
 ort = { version = "2.0.0-rc.4", default-features = false }
+
+# Web server dependencies
+axum = { version = "0.7", features = ["http2", "macros"] }
+tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
+tower = { version = "0.4", features = ["full"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+serde = { version = "1.0", features = ["derive"] }
+hyper = { version = "1.0", features = ["full"] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 ort = { version = "2.0.0-rc.4", features = ["coreml"] }
+
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 ort = { version = "2.0.0-rc.4", features = [] }

--- a/README.md
+++ b/README.md
@@ -30,40 +30,80 @@ Languge support:
 
 ## Updates
 
+- ***`2025.01.15`***: OpenAI compatible server supported!
 - ***`2025.01.15`***: Phonemizer supported! Now `Kokoros` can inference E2E without anyother dependencies! Kudos to [@tstm](https://github.com/tstm);
 - ***`2025.01.13`***: Espeak-ng tokenizer and phonemizer supported! Kudos to [@mindreframer](https://github.com/mindreframer) ;
 - ***`2025.01.12`***: Released `Kokoros`;
 
+## Installation
 
-## Build
+1. Set up the Python environment:
 
-First, fetch the `voices.json` data, this is need same as Kokoro official step.
-
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r scripts/requirements.txt
 ```
+
+2. Initialize voice data:
+
+```bash
 python scripts/fetch_voices.py
 ```
 
-Run:
+This step fetches the required `voices.json` data file, which is necessary for voice synthesis.
 
-```shell
+3. Build the project:
+
+```bash
 cargo build --release
+```
 
-# test
+## Usage
+
+Test the installation:
+
+```bash
 cargo run
 ```
 
-For production:
+For production use:
 
-```shell
-
-cargo build --release
-
-./target/release/koko -h
-./target/release/koko -t 'Hello, this is a TTS test'
+```bash
+./target/release/koko -h        # View available options
+./target/release/koko -t "Hello, this is a TTS test"
 ```
 
-For further development, for example, supports on embeded etc, please raise an issue to discuss your requirement.
+The generated audio will be saved to:
+```
+tmp/output.wav
+```
 
+### OpenAI-Compatible Server
+
+1. Start the server:
+
+```bash
+cargo run -- --oai
+```
+
+2. Make API requests using either curl or Python:
+
+Using curl:
+```bash
+curl -X POST http://localhost:3000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tts-1",
+    "input": "Hello, this is a test of the Kokoro TTS system!",
+    "voice": "af_sky"
+  }'
+```
+
+Using Python:
+```bash
+python scripts/run_openai.py
+```
 
 ## Roadmap
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.24.0
+requests>=2.31.0
+torch>=2.0.0 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+numpy>=1.24.0
+requests>=2.31.0
+torch>=2.0.0
+requests>=2.31.0

--- a/scripts/run_openai.py
+++ b/scripts/run_openai.py
@@ -1,0 +1,11 @@
+import requests
+
+url = "http://localhost:3000/v1/audio/speech"
+payload = {
+    "model": "tts-1",
+    "input": "Hello, this is a test of the Kokoro TTS system!",
+    "voice": "af_sky"
+}
+
+response = requests.post(url, json=payload)
+print(response.json())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod utils;
 
 use clap::Parser;
 use tts::koko::TTSKoko;
+use std::net::SocketAddr;
 
 #[derive(Parser, Debug)]
 #[command(name = "kokoros")]
@@ -18,23 +19,36 @@ struct Cli {
     oai: bool,
 }
 
-fn main() {
-    let args = Cli::parse();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let args = Cli::parse();
 
-    if args.oai {
-        println!("OpenAI like server still need help!")
-    } else {
-        let txt = args.text.unwrap_or_else(|| {
-            r#"
-            Hello, This is Kokoro. Your amazing AI TTS! A TTS model with only 82 million parameters that achieve incredible audio quality. 
-            This is the one of the best Rust inference, I help you will like it. 
-            Please give us a star if you do, thank you very much.
-            "#
-            .to_string()
-        });
+        if args.oai {
+            let tts = TTSKoko::new("checkpoints/kokoro-v0_19.onnx");
+            let app = serve::openai::create_server(tts).await;
+            
+            let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
+            println!("Starting OpenAI-compatible server on http://localhost:3000");
+            axum::serve(
+                tokio::net::TcpListener::bind(&addr).await?,
+                app.into_make_service(),
+            )
+            .await?;
+            Ok(())
+        } else {
+            let txt = args.text.unwrap_or_else(|| {
+                r#"
+                Hello, This is Kokoro. Your amazing AI TTS! A TTS model with only 82 million parameters that achieve incredible audio quality. 
+                This is the one of the best Rust inference, I help you will like it. 
+                Please give us a star if you do, thank you very much.
+                "#
+                .to_string()
+            });
 
-        let tts = TTSKoko::new("checkpoints/kokoro-v0_19.onnx");
-
-        tts.tts(&txt, "en-us", "af_sky");
-    }
+            let tts = TTSKoko::new("checkpoints/kokoro-v0_19.onnx");
+            tts.tts(&txt, "en-us", "af_sky");
+            Ok(())
+        }
+    })
 }

--- a/src/serve/openai.rs
+++ b/src/serve/openai.rs
@@ -1,0 +1,53 @@
+use axum::{
+    routing::post,
+    Router,
+    Json,
+    extract::State,
+};
+use serde::{Deserialize, Serialize};
+use tower_http::cors::CorsLayer;
+use crate::tts::koko::TTSKoko;
+use axum::http::StatusCode;
+
+#[derive(Deserialize)]
+struct TTSRequest {
+    model: String,
+    input: String,
+    voice: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TTSResponse {
+    status: String,
+    file_path: String,
+}
+
+pub async fn create_server(tts: TTSKoko) -> Router {
+    Router::new()
+        .route("/v1/audio/speech", post(handle_tts))
+        .layer(CorsLayer::permissive())
+        .with_state(tts)
+}
+
+async fn handle_tts(
+    State(tts): State<TTSKoko>,
+    Json(payload): Json<TTSRequest>,
+) -> Result<Json<TTSResponse>, StatusCode> {
+    let voice = payload.voice.unwrap_or_else(|| "af_sky".to_string());
+    
+    // Generate unique output filename
+    let output_path = format!("output_{}.wav", std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs());
+
+    // Process TTS request
+    if let Err(_) = tts.tts(&payload.input, "en-us", &voice) {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    Ok(Json(TTSResponse {
+        status: "success".to_string(),
+        file_path: output_path,
+    }))
+}

--- a/src/utils/fileio.rs
+++ b/src/utils/fileio.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{copy, Read, Write},
+    io::{Read, Write},
     path::Path,
 };
 


### PR DESCRIPTION
   This PR adds OpenAI-compatible server:

   - Add configurable host and port for server
   - Add configurable output directory
   - Improve error handling in TTS service
   - Add proper state management for server
   
   In terminal one:
   
   ```bash
   cargo run -- --oai
   ```
   
   In terminal two:
   
   ```
   curl -X POST http://localhost:3000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "tts-1",
    "input": "Hello, this is a test of the Kokoro TTS system!",
    "voice": "af_sarah"
  }'
  ```
