### PR TITLE
Chore: print loaded styles in sorted order

### DIFF
--- a/src/tts/koko.rs
+++ b/src/tts/koko.rs
@@ -203,7 +203,9 @@ impl TTSKoko {
             }
 
             println!("voice styles loaded: {}", self.styles.len());
-            println!("{:?}", self.styles.keys());
+            let mut keys: Vec<_> = self.styles.keys().cloned().collect();
+            keys.sort();
+            println!("{:?}", keys);
             println!(
                 "{:?} {:?}",
                 self.styles.keys().next(),


### PR DESCRIPTION
Problem: 
- it can be confusing to see / try new voices, if the printed order changes with each CLI execution 

Solution: 
- sort them before printing