### PR TITLE
Add raw audio output support to OpenAI API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ name = "koko"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64",
  "clap",
  "espeak-rs",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 serde = { version = "1.0", features = ["derive"] }
 hyper = { version = "1.0", features = ["full"] }
+base64 = "0.22.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 ort = { version = "2.0.0-rc.4", features = ["coreml"] }

--- a/src/serve/openai.rs
+++ b/src/serve/openai.rs
@@ -1,25 +1,23 @@
-use axum::{
-    routing::post,
-    Router,
-    Json,
-    extract::State,
-};
-use serde::{Deserialize, Serialize};
-use tower_http::cors::CorsLayer;
 use crate::tts::koko::TTSKoko;
 use axum::http::StatusCode;
+use axum::{extract::State, routing::post, Json, Router};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tower_http::cors::CorsLayer;
 
 #[derive(Deserialize)]
 struct TTSRequest {
     model: String,
     input: String,
     voice: Option<String>,
+    return_audio: Option<bool>,
 }
 
 #[derive(Serialize)]
 struct TTSResponse {
     status: String,
-    file_path: String,
+    file_path: Option<String>, // Made optional since we won't always have a file
+    audio: Option<String>,     // Made optional since we won't always return audio
 }
 
 pub async fn create_server(tts: TTSKoko) -> Router {
@@ -34,20 +32,54 @@ async fn handle_tts(
     Json(payload): Json<TTSRequest>,
 ) -> Result<Json<TTSResponse>, StatusCode> {
     let voice = payload.voice.unwrap_or_else(|| "af_sky".to_string());
-    
-    // Generate unique output filename
-    let output_path = format!("output_{}.wav", std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs());
+    let return_audio = payload.return_audio.unwrap_or(false);
 
-    // Process TTS request
-    if let Err(_) = tts.tts(&payload.input, "en-us", &voice) {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    match tts.tts_raw_audio(&payload.input, "en-us", &voice) {
+        Ok((audio_data, raw_audio)) => {
+            if return_audio {
+                let audio_base64 = base64::engine::general_purpose::STANDARD.encode(&audio_data);
+                Ok(Json(TTSResponse {
+                    status: "success".to_string(),
+                    file_path: None,
+                    audio: Some(audio_base64),
+                }))
+            } else {
+                let output_path = format!(
+                    "output_{}.wav",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs()
+                );
+
+                // Create WAV file
+                let spec = hound::WavSpec {
+                    channels: 1,
+                    sample_rate: 24000, // Using the same sample rate as in TTSKoko
+                    bits_per_sample: 32,
+                    sample_format: hound::SampleFormat::Float,
+                };
+
+                if let Ok(mut writer) = hound::WavWriter::create(&output_path, spec) {
+                    for &sample in &raw_audio {
+                        if writer.write_sample(sample).is_err() {
+                            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                        }
+                    }
+                    if writer.finalize().is_err() {
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                    }
+
+                    Ok(Json(TTSResponse {
+                        status: "success".to_string(),
+                        file_path: Some(output_path),
+                        audio: None,
+                    }))
+                } else {
+                    Err(StatusCode::INTERNAL_SERVER_ERROR)
+                }
+            }
+        }
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }
-
-    Ok(Json(TTSResponse {
-        status: "success".to_string(),
-        file_path: output_path,
-    }))
 }

--- a/src/serve/openai.rs
+++ b/src/serve/openai.rs
@@ -45,7 +45,7 @@ async fn handle_tts(
                 }))
             } else {
                 let output_path = format!(
-                    "output_{}.wav",
+                    "tmp/output_{}.wav",
                     std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap()


### PR DESCRIPTION
This commit introduces support for returning raw audio data from the OpenAI API. The following changes were made:

- **New Dependency:** Added `base64` crate to handle audio data encoding.
- **Updated TTSRequest Structure:** Added optional `return_audio` field to specify whether to return audio data as base64.
- **Modified TTSResponse Structure:** Made `file_path` optional and added `audio` field to accommodate raw audio output.
- **Refactored handle_tts Function:** Implemented logic to return audio data in base64 format if requested, or save it as a WAV file if not.
- **Introduced tts_raw_audio Method:** Added new method in `TTSKoko` for generating raw audio data, which returns both audio bytes and raw audio samples.
- **Updated tts Method:** Refactored to utilize the new `tts_raw_audio` method and save audio to a file.

These enhancements provide greater flexibility for users of the API by allowing them to either retrieve audio directly or obtain a file path for saved audio.