### PR TITLE
Streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ name = "koko"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64",
  "clap",
  "espeak-rs",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 serde = { version = "1.0", features = ["derive"] }
 hyper = { version = "1.0", features = ["full"] }
+base64 = "0.22.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 ort = { version = "2.0.0-rc.4", features = ["coreml"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,10 @@ mod serve;
 mod tts;
 mod utils;
 
+use std::io::Write;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use crate::utils::wav::{write_audio_chunk, WavHeader};
 use clap::Parser;
 use std::net::SocketAddr;
 use tts::koko::TTSKoko;
@@ -31,6 +35,46 @@ struct Cli {
 
     #[arg(long = "oai", value_name = "OpenAI server")]
     oai: bool,
+
+    #[arg(long = "stream", help = "Enable streaming mode")]
+    stream: bool,
+}
+async fn handle_streaming_mode(
+    tts: &TTSKoko,
+    lan: &str,
+    style: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let stdin = tokio::io::stdin();
+    let reader = BufReader::new(stdin);
+    let mut lines = reader.lines();
+
+    // Use std::io::stdout() for sync writing
+    let mut stdout = std::io::stdout();
+
+    // Write WAV header first
+    eprintln!("Entering streaming mode. Type text and press Enter. Use Ctrl+D to exit.");
+
+    let header = WavHeader::new(1, 24000, 32);
+    header.write_header(&mut stdout)?;
+    stdout.flush()?;
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Process the line and get audio data
+        match tts.tts_raw_audio(&line, lan, style) {
+            Ok((_, raw_audio)) => {
+                // Write the raw audio samples directly
+                write_audio_chunk(&mut stdout, &raw_audio)?;
+                stdout.flush()?;
+            }
+            Err(e) => eprintln!("Error processing line: {}", e),
+        }
+    }
+
+    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -47,7 +91,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let tts = TTSKoko::new(&model_path);
 
-        if args.oai {
+        if args.stream {
+            handle_streaming_mode(&tts, &lan, &style).await?;
+            Ok(())
+        } else if args.oai {
             let app = serve::openai::create_server(tts).await;
             let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
             println!("Starting OpenAI-compatible server on http://localhost:3000");
@@ -61,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let txt = args.text.unwrap_or_else(|| {
                 r#"
                 Hello, This is Kokoro, your remarkable AI TTS. It's a TTS model with merely 82 million parameters yet delivers incredible audio quality.
-This is one of the top notch Rust based inference models, and I'm sure you'll love it. If you do, please give us a star. Thank you very much. 
+This is one of the top notch Rust based inference models, and I'm sure you'll love it. If you do, please give us a star. Thank you very much.
  As the night falls, I wish you all a peaceful and restful sleep. May your dreams be filled with joy and happiness. Good night, and sweet dreams!
                 "#
                 .to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn handle_streaming_mode(
 
         // Process the line and get audio data
         match tts.tts_raw_audio(&line, lan, style) {
-            Ok((_, raw_audio)) => {
+            Ok(raw_audio) => {
                 // Write the raw audio samples directly
                 write_audio_chunk(&mut stdout, &raw_audio)?;
                 stdout.flush()?;

--- a/src/onn/ort_base.rs
+++ b/src/onn/ort_base.rs
@@ -17,16 +17,16 @@ pub trait OrtBase {
 
     fn print_info(&self) {
         if let Some(session) = self.sess() {
-            println!("Input names:");
+            eprintln!("Input names:");
             for input in &session.inputs {
-                println!("  - {}", input.name);
+                eprintln!("  - {}", input.name);
             }
-            println!("Output names:");
+            eprintln!("Output names:");
             for output in &session.outputs {
-                println!("  - {}", output.name);
+                eprintln!("  - {}", output.name);
             }
         } else {
-            println!("Session is not initialized.");
+            eprintln!("Session is not initialized.");
         }
     }
 

--- a/src/onn/ort_koko.rs
+++ b/src/onn/ort_koko.rs
@@ -44,7 +44,7 @@ impl OrtKoko {
         let tokens_value: SessionInputValue = SessionInputValue::Owned(Value::from(tokens));
 
         let shape_style = [styles.len(), styles[0].len()];
-        println!("shape_style: {:?}", shape_style);
+        eprintln!("shape_style: {:?}", shape_style);
         let style_flat: Vec<f32> = styles.into_iter().flatten().collect();
         let style = Tensor::from_array((shape_style, style_flat))?;
         let style_value: SessionInputValue = SessionInputValue::Owned(Value::from(style));

--- a/src/serve/openai.rs
+++ b/src/serve/openai.rs
@@ -1,25 +1,23 @@
-use axum::{
-    routing::post,
-    Router,
-    Json,
-    extract::State,
-};
-use serde::{Deserialize, Serialize};
-use tower_http::cors::CorsLayer;
 use crate::tts::koko::TTSKoko;
 use axum::http::StatusCode;
+use axum::{extract::State, routing::post, Json, Router};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tower_http::cors::CorsLayer;
 
 #[derive(Deserialize)]
 struct TTSRequest {
     model: String,
     input: String,
     voice: Option<String>,
+    return_audio: Option<bool>,
 }
 
 #[derive(Serialize)]
 struct TTSResponse {
     status: String,
-    file_path: String,
+    file_path: Option<String>, // Made optional since we won't always have a file
+    audio: Option<String>,     // Made optional since we won't always return audio
 }
 
 pub async fn create_server(tts: TTSKoko) -> Router {
@@ -34,20 +32,54 @@ async fn handle_tts(
     Json(payload): Json<TTSRequest>,
 ) -> Result<Json<TTSResponse>, StatusCode> {
     let voice = payload.voice.unwrap_or_else(|| "af_sky".to_string());
-    
-    // Generate unique output filename
-    let output_path = format!("output_{}.wav", std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs());
+    let return_audio = payload.return_audio.unwrap_or(false);
 
-    // Process TTS request
-    if let Err(_) = tts.tts(&payload.input, "en-us", &voice) {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    match tts.tts_raw_audio(&payload.input, "en-us", &voice) {
+        Ok((audio_data, raw_audio)) => {
+            if return_audio {
+                let audio_base64 = base64::engine::general_purpose::STANDARD.encode(&audio_data);
+                Ok(Json(TTSResponse {
+                    status: "success".to_string(),
+                    file_path: None,
+                    audio: Some(audio_base64),
+                }))
+            } else {
+                let output_path = format!(
+                    "output_{}.wav",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs()
+                );
+
+                // Create WAV file
+                let spec = hound::WavSpec {
+                    channels: 1,
+                    sample_rate: 24000, // Using the same sample rate as in TTSKoko
+                    bits_per_sample: 32,
+                    sample_format: hound::SampleFormat::Float,
+                };
+
+                if let Ok(mut writer) = hound::WavWriter::create(&output_path, spec) {
+                    for &sample in &raw_audio {
+                        if writer.write_sample(sample).is_err() {
+                            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                        }
+                    }
+                    if writer.finalize().is_err() {
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                    }
+
+                    Ok(Json(TTSResponse {
+                        status: "success".to_string(),
+                        file_path: Some(output_path),
+                        audio: None,
+                    }))
+                } else {
+                    Err(StatusCode::INTERNAL_SERVER_ERROR)
+                }
+            }
+        }
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }
-
-    Ok(Json(TTSResponse {
-        status: "success".to_string(),
-        file_path: output_path,
-    }))
 }

--- a/src/tts/vocab.rs
+++ b/src/tts/vocab.rs
@@ -22,12 +22,13 @@ pub fn get_reverse_vocab() -> HashMap<usize, char> {
     VOCAB.iter().map(|(&c, &idx)| (idx, c)).collect()
 }
 
+#[allow(dead_code)]
 pub fn print_sorted_reverse_vocab() {
     let mut sorted_keys: Vec<_> = REVERSE_VOCAB.keys().collect();
     sorted_keys.sort();
 
     for key in sorted_keys {
-        println!("{}: {}", key, REVERSE_VOCAB[key]);
+        eprintln!("{}: {}", key, REVERSE_VOCAB[key]);
     }
 }
 

--- a/src/utils/fileio.rs
+++ b/src/utils/fileio.rs
@@ -19,7 +19,7 @@ pub fn download_file_from_url(url: &str, path: &str) -> Result<(), Box<dyn std::
     if resp.status().is_success() {
         let total_size = resp.content_length().unwrap_or(0);
 
-        println!("total size: {}", total_size);
+        eprintln!("total size: {}", total_size);
 
         let pb = ProgressBar::new(total_size);
         pb.set_style(ProgressStyle::default_bar()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod fileio;
+pub mod wav;

--- a/src/utils/wav.rs
+++ b/src/utils/wav.rs
@@ -1,0 +1,50 @@
+use std::io::{self, Write};
+
+pub struct WavHeader {
+    pub channels: u16,
+    pub sample_rate: u32,
+    pub bits_per_sample: u16,
+}
+
+impl WavHeader {
+    pub fn new(channels: u16, sample_rate: u32, bits_per_sample: u16) -> Self {
+        Self {
+            channels,
+            sample_rate,
+            bits_per_sample,
+        }
+    }
+
+    pub fn write_header<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        // RIFF header
+        writer.write_all(b"RIFF")?;
+        writer.write_all(&[0xFF, 0xFF, 0xFF, 0xFF])?; // File size - 8 (placeholder)
+        writer.write_all(b"WAVE")?;
+
+        // Format chunk
+        writer.write_all(b"fmt ")?;
+        writer.write_all(&(16u32).to_le_bytes())?; // Format chunk size
+        writer.write_all(&(3u16).to_le_bytes())?; // Format = 3 (IEEE float)
+        writer.write_all(&self.channels.to_le_bytes())?;
+        writer.write_all(&self.sample_rate.to_le_bytes())?;
+        let byte_rate =
+            self.sample_rate * u32::from(self.channels) * u32::from(self.bits_per_sample) / 8;
+        writer.write_all(&byte_rate.to_le_bytes())?;
+        let block_align = self.channels * self.bits_per_sample / 8;
+        writer.write_all(&block_align.to_le_bytes())?;
+        writer.write_all(&self.bits_per_sample.to_le_bytes())?;
+
+        // Data chunk header
+        writer.write_all(b"data")?;
+        writer.write_all(&[0xFF, 0xFF, 0xFF, 0xFF])?; // Data size (placeholder)
+
+        Ok(())
+    }
+}
+
+pub fn write_audio_chunk<W: Write>(writer: &mut W, samples: &[f32]) -> io::Result<()> {
+    for sample in samples {
+        writer.write_all(&sample.to_le_bytes())?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
feat: add streaming mode 

- Introduced a new CLI argument `--stream` to enable streaming mode.
- Implemented `handle_streaming_mode` function to read lines from stdin and process them.
- Added WAV header writing functionality to manage audio output format.
- Enhanced error handling and output messaging during the audio processing.
- Refactored audio writing logic into utility functions for better code organization.
- Updated main function to conditionally handle streaming, 'normal', or OpenAI server modes.

