### PR TITLE
[feat] default output to stereo - optional output mono

### DIFF
--- a/src/tts/koko.rs
+++ b/src/tts/koko.rs
@@ -9,6 +9,14 @@ use crate::utils::fileio::load_json_file;
 
 use espeak_rs::text_to_phonemes;
 
+pub struct TTSOpts<'a> {
+    pub txt: &'a str,
+    pub lan: &'a str,
+    pub style_name: &'a str,
+    pub save_path: &'a str,
+    pub mono: bool,
+}
+
 #[derive(Clone)]
 pub struct TTSKoko {
     #[allow(dead_code)]
@@ -172,28 +180,45 @@ impl TTSKoko {
 
     pub fn tts(
         &self,
-        txt: &str,
-        lan: &str,
-        style_name: &str,
-        save_path: &str,
+        TTSOpts {
+            txt,
+            lan,
+            style_name,
+            save_path,
+            mono,
+        }: TTSOpts,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let audio = self.tts_raw_audio(&txt, lan, style_name)?;
 
         // Save to file
-        let spec = hound::WavSpec {
-            channels: 2,
-            sample_rate: TTSKoko::SAMPLE_RATE,
-            bits_per_sample: 32,
-            sample_format: hound::SampleFormat::Float,
-        };
+        if mono {
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate: TTSKoko::SAMPLE_RATE,
+                bits_per_sample: 32,
+                sample_format: hound::SampleFormat::Float,
+            };
 
-        let mut writer = hound::WavWriter::create(save_path, spec)?;
-        for &sample in &audio {
-            writer.write_sample(sample)?;
-            writer.write_sample(sample)?;
+            let mut writer = hound::WavWriter::create(save_path, spec)?;
+            for &sample in &audio {
+                writer.write_sample(sample)?;
+            }
+            writer.finalize()?;
+        } else {
+            let spec = hound::WavSpec {
+                channels: 2,
+                sample_rate: TTSKoko::SAMPLE_RATE,
+                bits_per_sample: 32,
+                sample_format: hound::SampleFormat::Float,
+            };
+
+            let mut writer = hound::WavWriter::create(save_path, spec)?;
+            for &sample in &audio {
+                writer.write_sample(sample)?;
+                writer.write_sample(sample)?;
+            }
+            writer.finalize()?;
         }
-        writer.finalize()?;
-
         eprintln!("Audio saved to {}", save_path);
         Ok(())
     }

--- a/src/tts/koko.rs
+++ b/src/tts/koko.rs
@@ -181,7 +181,7 @@ impl TTSKoko {
 
         // Save to file
         let spec = hound::WavSpec {
-            channels: 1,
+            channels: 2,
             sample_rate: TTSKoko::SAMPLE_RATE,
             bits_per_sample: 32,
             sample_format: hound::SampleFormat::Float,
@@ -189,6 +189,7 @@ impl TTSKoko {
 
         let mut writer = hound::WavWriter::create(save_path, spec)?;
         for &sample in &audio {
+            writer.write_sample(sample)?;
             writer.write_sample(sample)?;
         }
         writer.finalize()?;


### PR DESCRIPTION
Feat https://github.com/lucasjinreal/Kokoros/issues/43

> 2 channel audio output should be a default option.

By default, output wav file is now stereo.

You can obtain the old behavior, namely obtain a mono wav file, by adding the --mono flag.

```
cargo run -- --mono
```