### PR TITLE
More robust CLI mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,34 @@ cargo build --release
 
 ## Usage
 
-Test the installation:
+### View available options
 
 ```bash
-cargo run
+./target/release/koko -h
 ```
 
-For production use:
-
-```bash
-./target/release/koko -h        # View available options
-./target/release/koko -t "Hello, this is a TTS test"
-```
-
-The generated audio will be saved to:
+### Generate speech for some text
 
 ```
-tmp/output.wav
+./target/release/koko text "Hello, this is a TTS test"
+```
+
+The generated audio will be saved to `tmp/output.wav` by default. You can customize the save location with the `--output` or `-o` option:
+
+```
+./target/release/koko text "I hope you're having a great day today!" --output greeting.wav
+```
+
+### Generate speech for each line in a file
+
+```
+./target/release/koko file poem.txt
+```
+
+For a file with 3 lines of text, by default, speech audio files `tmp/output_0.wav`, `tmp/output_1.wav`, `tmp/output_2.wav` will be outputted. You can customize the save location with the `--output` or `-o` option, using `{line}` as the line number:
+
+```
+./target/release/koko file lyrics.txt -o "song/lyric_{line}.wav"
 ```
 
 ### OpenAI-Compatible Server
@@ -94,7 +105,7 @@ tmp/output.wav
 1. Start the server:
 
 ```bash
-cargo run -- --oai
+./target/release/koko openai
 ```
 
 2. Make API requests using either curl or Python:
@@ -117,6 +128,27 @@ Using Python:
 python scripts/run_openai.py
 ```
 
+### Streaming
+
+The `stream` option will start the program, reading for lines of input from stdin and outputting WAV audio to stdout.
+
+Use it in conjunction with piping.
+
+#### Typing manually
+
+```
+./target/release/koko stream > live-audio.wav
+# Start typing some text to generate speech for and hit enter to submit
+# Speech will append to `live-audio.wav` as it is generated
+# Hit Ctrl D to exit
+```
+
+#### Input from another source
+
+```
+echo "Suppose some other program was outputting lines of text" | ./target/release/koko stream > programmatic-audio.wav
+```
+
 ### With docker
 
 1. Build the image
@@ -125,10 +157,14 @@ python scripts/run_openai.py
 docker build -t kokoros .
 ```
 
-2. Run the image
+2. Run the image, passing options as described above
 
 ```bash
-docker run -p 3000:3000 -v ./tmp:/app/tmp kokoros
+# Basic text to speech
+docker run -v ./tmp:/app/tmp kokoros text "Hello from docker!" -o tmp/hello.wav
+
+# An OpenAI server (with appropriately bound port)
+docker run -p 3000:3000 kokoros openai
 ```
 
 ## Roadmap

--- a/koko/src/main.rs
+++ b/koko/src/main.rs
@@ -1,48 +1,96 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use kokoros::{
     tts::koko::{TTSKoko, TTSOpts},
     utils::wav::{write_audio_chunk, WavHeader},
 };
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::{
     fs::{self},
     io::Write,
-    path::Path,
 };
 use tokio::io::{AsyncBufReadExt, BufReader};
+
+#[derive(Subcommand, Debug)]
+enum Mode {
+    /// Generate speech for a string of text
+    #[command(alias = "t", long_flag_alias = "text", short_flag_alias = 't')]
+    Text {
+        /// Text to generate speech for
+        #[arg(
+            default_value = "Hello, This is Kokoro, your remarkable AI TTS. It's a TTS model with merely 82 million parameters yet delivers incredible audio quality.
+                This is one of the top notch Rust based inference models, and I'm sure you'll love it. If you do, please give us a star. Thank you very much.
+                As the night falls, I wish you all a peaceful and restful sleep. May your dreams be filled with joy and happiness. Good night, and sweet dreams!"
+        )]
+        text: String,
+
+        /// Path to output the WAV file to on the filesystem
+        #[arg(
+            short = 'o',
+            long = "output",
+            value_name = "OUTPUT_PATH",
+            default_value = "tmp/output.wav"
+        )]
+        save_path: String,
+    },
+
+    /// Read from a file path and generate a speech file for each line
+    #[command(alias = "f", long_flag_alias = "file", short_flag_alias = 'f')]
+    File {
+        /// Filesystem path to read lines from
+        input_path: String,
+
+        /// Format for the output path of each WAV file, where {line} will be replaced with the line number
+        #[arg(
+            short = 'o',
+            long = "output",
+            value_name = "OUTPUT_PATH_FORMAT",
+            default_value = "tmp/output_{line}.wav"
+        )]
+        save_path_format: String,
+    },
+
+    /// Continuously read from stdin to generate speech, outputting to stdout, for each line
+    #[command(aliases = ["stdio", "stdin", "-"], long_flag_aliases = ["stdio", "stdin"])]
+    Stream,
+
+    /// Start an OpenAI-compatible HTTP server
+    #[command(name = "openai", alias = "oai", long_flag_aliases = ["oai", "openai"])]
+    OpenAI {
+        /// IP address to bind to (typically 127.0.0.1 or 0.0.0.0)
+        #[arg(long, default_value_t = [0, 0, 0, 0].into())]
+        ip: IpAddr,
+
+        /// Port to expose the HTTP server on
+        #[arg(long, default_value_t = 3000)]
+        port: u16,
+    },
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "kokoros")]
 #[command(version = "0.1")]
 #[command(author = "Lucas Jin")]
 struct Cli {
-    #[arg(
-        short = 't',
-        long = "text",
-        value_name = "TEXT",
-        default_value = "Hello, This is Kokoro, your remarkable AI TTS. It's a TTS model with merely 82 million parameters yet delivers incredible audio quality.
-        This is one of the top notch Rust based inference models, and I'm sure you'll love it. If you do, please give us a star. Thank you very much.
-        As the night falls, I wish you all a peaceful and restful sleep. May your dreams be filled with joy and happiness. Good night, and sweet dreams!"
-    )]
-    text: String,
-
+    /// A language identifier from
+    /// https://github.com/espeak-ng/espeak-ng/blob/master/docs/languages.md
     #[arg(
         short = 'l',
         long = "lan",
         value_name = "LANGUAGE",
-        help = "https://github.com/espeak-ng/espeak-ng/blob/master/docs/languages.md",
         default_value = "en-us"
     )]
     lan: String,
 
+    /// Path to the Kokoro v0.19 ONNX model on the filesystem
     #[arg(
         short = 'm',
         long = "model",
-        value_name = "MODEL",
+        value_name = "MODEL_PATH",
         default_value = "checkpoints/kokoro-v0_19.onnx"
     )]
     model_path: String,
 
+    /// Which single voice to use or voices to combine to serve as the style of speech
     #[arg(
         short = 's',
         long = "style",
@@ -53,6 +101,9 @@ struct Cli {
     )]
     style: String,
 
+    /// Rate of speech, as a coefficient of the default
+    /// (i.e. 0.0 to 1.0 is slower than default,
+    /// whereas 1.0 and beyond is faster than default)
     #[arg(
         short = 'p',
         long = "speed",
@@ -61,124 +112,108 @@ struct Cli {
     )]
     speed: f32,
 
+    /// Output audio in mono (as opposed to stereo)
     #[arg(long = "mono", default_value_t = false)]
     mono: bool,
 
-    #[arg(long = "oai", value_name = "OpenAI server")]
-    oai: bool,
-
-    #[arg(long = "stream", help = "Enable streaming mode")]
-    stream: bool,
-
-    #[arg(
-        short = 'o',
-        long = "output",
-        value_name = "OUTPUT_PATH",
-        help = "Output path for WAV file",
-        default_value = "tmp/output.wav"
-    )]
-    save_path: String,
-}
-
-async fn handle_streaming_mode(
-    tts: &TTSKoko,
-    lan: &str,
-    style: &str,
-    speed: f32,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let stdin = tokio::io::stdin();
-    let reader = BufReader::new(stdin);
-    let mut lines = reader.lines();
-
-    // Use std::io::stdout() for sync writing
-    let mut stdout = std::io::stdout();
-
-    // Write WAV header first
-    eprintln!("Entering streaming mode. Type text and press Enter. Use Ctrl+D to exit.");
-
-    let header = WavHeader::new(1, 24000, 32);
-    header.write_header(&mut stdout)?;
-    stdout.flush()?;
-
-    while let Some(line) = lines.next_line().await? {
-        if line.trim().is_empty() {
-            continue;
-        }
-
-        // Process the line and get audio data
-        match tts.tts_raw_audio(&line, lan, style, speed) {
-            Ok(raw_audio) => {
-                // Write the raw audio samples directly
-                write_audio_chunk(&mut stdout, &raw_audio)?;
-                stdout.flush()?;
-            }
-            Err(e) => eprintln!("Error processing line: {}", e),
-        }
-    }
-
-    Ok(())
+    #[command(subcommand)]
+    mode: Mode,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let Cli {
-            text,
             lan,
             model_path,
             style,
             speed,
             mono,
-            oai,
-            stream,
-            save_path,
+            mode,
         } = Cli::parse();
 
         let tts = TTSKoko::new(&model_path).await;
 
-        if stream {
-            handle_streaming_mode(&tts, &lan, &style, speed).await?;
-            Ok(())
-        } else if oai {
-            let app = kokoros_openai::create_server(tts).await;
-            let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-            println!("Starting OpenAI-compatible server on http://localhost:3000");
-            kokoros_openai::serve(
-                tokio::net::TcpListener::bind(&addr).await?,
-                app.into_make_service(),
-            )
-            .await?;
-            Ok(())
-        } else {
-            let path = Path::new(&text);
-            if path.exists() && path.is_file() {
-                let file_content = fs::read_to_string(path)?;
+        match mode {
+            Mode::File {
+                input_path,
+                save_path_format,
+            } => {
+                let file_content = fs::read_to_string(input_path)?;
                 for (i, line) in file_content.lines().enumerate() {
                     let stripped_line = line.trim();
-                    if !stripped_line.is_empty() {
-                        let save_path = format!("{save_path}_{i}.wav");
-                        tts.tts(TTSOpts {
-                            txt: stripped_line,
-                            lan: &lan,
-                            style_name: &style,
-                            save_path: &save_path,
-                            mono,
-                            speed: speed,
-                        })?;
+                    if stripped_line.is_empty() {
+                        continue;
                     }
+
+                    let save_path = save_path_format.replace("{line}", &i.to_string());
+                    tts.tts(TTSOpts {
+                        txt: stripped_line,
+                        lan: &lan,
+                        style_name: &style,
+                        save_path: &save_path,
+                        mono,
+                        speed: speed,
+                    })?;
                 }
-                return Ok(());
             }
 
-            tts.tts(TTSOpts {
-                txt: &text,
-                lan: &lan,
-                style_name: &style,
-                save_path: &save_path,
-                mono,
-                speed,
-            })?;
-            Ok(())
+            Mode::Text { text, save_path } => {
+                tts.tts(TTSOpts {
+                    txt: &text,
+                    lan: &lan,
+                    style_name: &style,
+                    save_path: &save_path,
+                    mono,
+                    speed,
+                })?;
+            }
+
+            Mode::OpenAI { ip, port } => {
+                let app = kokoros_openai::create_server(tts).await;
+                let addr = SocketAddr::from((ip, port));
+                let binding = tokio::net::TcpListener::bind(&addr).await?;
+                println!("Starting OpenAI-compatible HTTP server on {addr}");
+                kokoros_openai::serve(binding, app.into_make_service()).await?;
+            }
+
+            Mode::Stream => {
+                let stdin = tokio::io::stdin();
+                let reader = BufReader::new(stdin);
+                let mut lines = reader.lines();
+
+                // Use std::io::stdout() for sync writing
+                let mut stdout = std::io::stdout();
+
+                eprintln!(
+                    "Entering streaming mode. Type text and press Enter. Use Ctrl+D to exit."
+                );
+
+                // Write WAV header first
+                let header = WavHeader::new(1, 24000, 32);
+                header.write_header(&mut stdout)?;
+                stdout.flush()?;
+
+                while let Some(line) = lines.next_line().await? {
+                    let stripped_line = line.trim();
+                    if stripped_line.is_empty() {
+                        continue;
+                    }
+
+                    // Process the line and get audio data
+                    match tts.tts_raw_audio(&stripped_line, &lan, &style, speed) {
+                        Ok(raw_audio) => {
+                            // Write the raw audio samples directly
+                            write_audio_chunk(&mut stdout, &raw_audio)?;
+                            stdout.flush()?;
+                            eprintln!("Audio written to stdout. Ready for another line of text.");
+                        }
+                        Err(e) => eprintln!("Error processing line: {}", e),
+                    }
+                }
+            }
         }
+
+        Ok(())
     })
 }


### PR DESCRIPTION
This breaks down the CLI usage into four modes:
1. `text` for generating speech for a string of text
2. `file` for generating a speech file for each (non-empty) line from a file
3. `stream` for writing generated speech for each line of input (e.g. for use with piping)
4. `openai` for running the OpenAI-API-compatible HTTP server

All of these modes already existed in the CLI; this just organizes them into mutually exclusive options, fixing #51.

The one breaking change (I'm aware of) is that passing a file to text mode (e.g. `koko -t some-file.txt`) instead generates speech for "some-file.txt" (as a string of text, not the contents of the file); users must instead use file mode (i.e. `koko file some-file.txt` or `koko -f some-file.txt` or `koko --file some-text.txt`) in order to get a speech audio file for each line of the given input file. (This is definitely the right change to make in my opinion, but I'm pointing it out in case you or anyone reading needs to know to change their usage).

Aliases were included to reduce how much of a breaking change this is:
For example, `long_flag_alias = "text"` was added for the text mode so that it will still work for people who are used to running `koko --text "Some text here"`. `short_flag_alias = 't'` so that `koko -t "Some text"` still works.
Likewise for `long_flag_aliases = ["oai", "openai"]` for the OpenAI mode so that `koko --oai` and `koko --openai` work in addition to `koko openai`.
And so on; just highlighting a few.

`-` was added as an alias to stream mode because there are many command line programs where `-` means to read from stdin, so now `koko -` works for that.

The user can also now specify the binding IP address (default 0.0.0.0 which listens on all interfaces) and port (default 3000) of the OpenAI HTTP server.

Documentation and help text improvements included.
