### PR TITLE
feat: Add widening effect support for stereo output

### DIFF
--- a/kokoros/src/tts/koko.rs
+++ b/kokoros/src/tts/koko.rs
@@ -253,7 +253,7 @@ impl TTSKoko {
             for &sample in &audio {
                 writer.write_sample(sample)?;
             }
-        } else if stereo_phase_shift > 0.0 {
+        } else if stereo_phase_shift != 0.0 {
             let shifted_audio = apply_phase_shift(&audio, stereo_phase_shift);
 
             for i in 0..audio.len() {


### PR DESCRIPTION
feat: Add stereo phase shift support for audio output
- Introduced a new CLI option `--stereo-phase-shift` to apply a phase shift to stereo audio, allowing values between -1.0 and 1.0.
- Implemented `apply_phase_shift` function using an all-pass filter to modify the phase response of audio without significant amplitude alteration.
- Updated `TTSOpts` to include a `stereo_phase_shift` parameter.
- Adjusted audio generation logic to apply the phase shift for stereo outputs, ensuring compatibility with mono and stereo modes.
- Added warnings for invalid phase shift values or conflicting mono mode usage, providing clipping behavior when necessary.

This update enables a stereo widening effect through phase-shifted audio in the right channel when in stereo mode.
