### PR TITLE
feat: Add InitConfig for TTSKoko initialization parameters

### DIFF
--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::{extract::State, routing::post, Json, Router};
 use kokoros::{
-    tts::koko::TTSKoko,
+    tts::koko::{InitConfig as TTSKokoInitConfig, TTSKoko},
     utils::wav::{write_audio_chunk, WavHeader},
 };
 use serde::Deserialize;
@@ -104,7 +104,8 @@ async fn handle_tts(
         .tts_raw_audio(&input, "en-us", &voice, speed, initial_silence)
         .map_err(SpeechError::Koko)?;
     let mut wav_data = Vec::default();
-    let header = WavHeader::new(1, TTSKoko::SAMPLE_RATE, 32);
+    let sample_rate = TTSKokoInitConfig::default().sample_rate;
+    let header = WavHeader::new(1, sample_rate, 32);
     header
         .write_header(&mut wav_data)
         .map_err(SpeechError::Header)?;


### PR DESCRIPTION
Address #58 

Introduce a new InitConfig struct dedicated to TTSKoko initialization, allowing customization of the voices JSON file path, model URL, and sample rate.

You can use default values as usual:
```rust
﻿use kokoros::tts::koko::{TTSKoko, TTSOpts};

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let koko = TTSKoko::new("../Kokoros/checkpoints/kokoro-v0_19.onnx").await;
    let opts = TTSOpts {
        txt: "How is is everyone doing today? This is a simple example.",
        lan: "en-US",
        style_name: "af_sarah.4+af_nicole.6",
        save_path: "output.wav",
        mono: false,
        speed: 1.0,
        initial_silence: Some(5),
    };
    koko.tts(opts)?;
    Ok(())
}
```

But now if you want to change the voices.json file path and the sample rate, you can do it like so:
```rust
﻿﻿﻿﻿﻿use kokoros::tts::koko::{InitConfig, TTSKoko, TTSOpts};

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    // Create a default InitConfig and customize the parameters
    let onnx_path = "path/to/model.onnx";
    let mut config = InitConfig::default();

    // Customize the voices JSON file path and model URL
    config.json_data_f = "custom/path/to/voices.json".into();
    config.sample_rate = 24000; // For example, using 44100 Hz instead of 24000 Hz 

    // Initialize TTSKoko using the custom configuration
    let koko = TTSKoko::from_config(onnx_path, config).await;

    // Synthesis options remain the same using TTSOpts
    let opts = TTSOpts {
        txt: "Hello everyone! This is a custom initialization example.",
        lan: "en-US",
        style_name: "af_sarah.4+af_nicole.6",
        save_path: "custom_output.wav",
        mono: false,
        speed: 1.0,
        initial_silence: None,
    };

    koko.tts(opts)?;

    Ok(())
}

```