### PR TITLE
Return "200 OK" at OpenAI endpoint home

### DIFF
--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -61,8 +61,8 @@ struct SpeechRequest {
 
 pub async fn create_server(tts: TTSKoko) -> Router {
     Router::new()
+        .route("/", get(handle_home))
         .route("/v1/audio/speech", post(handle_tts))
-        .route("/v1/health", get(handle_health))
         .layer(CorsLayer::permissive())
         .with_state(tts)
 }
@@ -90,6 +90,12 @@ impl IntoResponse for SpeechError {
     }
 }
 
+/// Returns a 200 OK response to make it easier to check if the server is
+/// running.
+async fn handle_home() -> &'static str {
+    "OK"
+}
+
 async fn handle_tts(
     State(tts): State<TTSKoko>,
     Json(SpeechRequest {
@@ -113,8 +119,4 @@ async fn handle_tts(
     write_audio_chunk(&mut wav_data, &raw_audio).map_err(SpeechError::Chunk)?;
 
     Ok(wav_data)
-}
-
-async fn handle_health() -> &'static str {
-    "OK"
 }

--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::{extract::State, routing::post, Json, Router};
+use axum::{extract::State, routing::get, routing::post, Json, Router};
 use kokoros::{
     tts::koko::{InitConfig as TTSKokoInitConfig, TTSKoko},
     utils::wav::{write_audio_chunk, WavHeader},
@@ -62,6 +62,7 @@ struct SpeechRequest {
 pub async fn create_server(tts: TTSKoko) -> Router {
     Router::new()
         .route("/v1/audio/speech", post(handle_tts))
+        .route("/v1/health", get(handle_health))
         .layer(CorsLayer::permissive())
         .with_state(tts)
 }
@@ -112,4 +113,8 @@ async fn handle_tts(
     write_audio_chunk(&mut wav_data, &raw_audio).map_err(SpeechError::Chunk)?;
 
     Ok(wav_data)
+}
+
+async fn handle_health() -> &'static str {
+    "OK"
 }


### PR DESCRIPTION
I was trying to run the openai endpoint at fly.io but couldn't get the HTTP health checks to pass. Health checks are useful to verify that the service is online. This PR suggests to return "OK" at the home route (`/`) so that people can easily check that the service is running.

For example, after this change

```sh
$ curl http://localhost:3000
OK
```
while before it would return nothing
```sh
$ curl http://localhost:3000
```