### PR TITLE
Refactor infer function to address initial silence issue and prevent prefix change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1044,7 @@ dependencies = [
  "hound",
  "indicatif",
  "lazy_static",
+ "mp3lame-encoder",
  "ndarray",
  "ndarray-npy",
  "ort",
@@ -1169,6 +1179,27 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mp3lame-encoder"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc8c8b5cdbe788ccd1098c3d3635298a011cffdebdd3460c9ca5060a7551557b"
+dependencies = [
+ "libc",
+ "mp3lame-sys",
+]
+
+[[package]]
+name = "mp3lame-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21460ca4d833756cb700430888c67969e40b4560f50c226a0d258de551931ec"
+dependencies = [
+ "autotools",
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/kokoros/src/onn/ort_koko.rs
+++ b/kokoros/src/onn/ort_koko.rs
@@ -41,11 +41,11 @@ impl OrtKoko {
 
         // Prepend 3 tokens to the first entry, to workaround initial silence issue
         // Make sure the first token is 0, I think it might be important?
-        let mut tokens = tokens;
-        let mut first_entry = tokens[0].clone();
-        let initial_pause = vec![0, 30, 30, 30];
-        first_entry.splice(0..1, initial_pause);
-        tokens[0] = first_entry;
+        // let mut tokens = tokens;
+        // let mut first_entry = tokens[0].clone();
+        // let initial_pause = vec![0, 30, 30, 30];
+        // first_entry.splice(0..1, initial_pause);
+        // tokens[0] = first_entry;
 
         let shape = [tokens.len(), tokens[0].len()];
         let tokens_flat: Vec<i64> = tokens.into_iter().flatten().collect();


### PR DESCRIPTION
- The initial silence issue was causing a weird sound to be prefixed to the output audio, such as "cc Hello" or "a so my name is Louis".

- This commit removes the token prepending logic to prevent the prefix change.

- The infer function now only returns the predicted text and the audio output.

-  The commented-out code is retained for reference and potential future adjustments if the initial silence issue re-emerges.