### PR TITLE
Add optional cuda and coreml features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1110,6 +1110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,9 +1524,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -1634,8 +1640,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1914,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
@@ -1933,7 +1952,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -2317,7 +2336,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2477,13 +2496,12 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xattr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "rustix 1.0.5",
 ]
 
 [[package]]

--- a/kokoros/Cargo.toml
+++ b/kokoros/Cargo.toml
@@ -14,15 +14,13 @@ reqwest = { version = "0.12.12" }
 serde_json = "1.0.135"
 tokio = { version = "1.0", features = ["fs", "io-util"] }
 ndarray-npy = "0.9.1"
-
 mp3lame-encoder = "0.2.1"
 
-
-# ONNX Runtime dependencies
+# Base ONNX Runtime configuration
 ort = { version = "2.0.0-rc.9", default-features = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-ort = { version = "2.0.0-rc.9", features = ["coreml"] }
-
-[target.'cfg(not(target_os = "macos"))'.dependencies]
-ort = { version = "2.0.0-rc.9", features = [] }
+[features]
+default = ["cpu"]
+cpu = []
+cuda = ["ort/cuda"]
+coreml = ["ort/coreml"]

--- a/kokoros/src/onn/ort_base.rs
+++ b/kokoros/src/onn/ort_base.rs
@@ -1,11 +1,30 @@
+#[cfg(feature = "cuda")]
+use ort::execution_providers::cuda::CUDAExecutionProvider;
+#[cfg(feature = "coreml")]
+use ort::execution_providers::coreml::CoreMLExecutionProvider;
+use ort::execution_providers::cpu::CPUExecutionProvider;
 use ort::session::builder::SessionBuilder;
 use ort::session::Session;
 
 pub trait OrtBase {
     fn load_model(&mut self, model_path: String) -> Result<(), String> {
+        #[cfg(feature = "cuda")]
+        let providers = [CUDAExecutionProvider::default().build()];
+
+        #[cfg(feature = "coreml")]
+        let providers = [
+            CoreMLExecutionProvider::default().build(),
+            CPUExecutionProvider::default().build()
+        ];
+
+        #[cfg(all(not(feature = "cuda"), not(feature = "coreml")))]
+        let providers = [CPUExecutionProvider::default().build()];
+
         match SessionBuilder::new() {
             Ok(builder) => {
                 let session = builder
+                    .with_execution_providers(providers)
+                    .map_err(|e| format!("Failed to build session: {}", e))?
                     .commit_from_file(model_path)
                     .map_err(|e| format!("Failed to commit from file: {}", e))?;
                 self.set_sess(session);
@@ -25,6 +44,15 @@ pub trait OrtBase {
             for output in &session.outputs {
                 eprintln!("  - {}", output.name);
             }
+
+            #[cfg(feature = "cuda")]
+            eprintln!("Configured with: CUDA execution provider");
+
+            #[cfg(feature = "coreml")]
+            eprintln!("Configured with: CoreML execution provider");
+
+            #[cfg(all(not(feature = "cuda"), not(feature = "coreml")))]
+            eprintln!("Configured with: CPU execution provider");
         } else {
             eprintln!("Session is not initialized.");
         }


### PR DESCRIPTION
## Changes
Allow users of the library to use cuda or coreml by passing a feature flag but use CPU by default.

## Testing
Tested with cuda on debian (WSL). With the cuda flag enabled, a paragraph that would normally take 9 seconds on cpu would complete in less than 2 seconds.

Attempted enabling coreml on an M1 macbook but was getting some linker errors. It should work though so there might be something wrong with my local environment.