### PR TITLE
Updated base images, fixed model/voice dl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,20 +9,21 @@ COPY . .
 COPY Cargo.toml .
 COPY Cargo.lock .
 
-RUN cargo build --release
 RUN chmod +x ./download_all.sh && ./download_all.sh
+
+RUN cargo build --release
 
 FROM debian:sid-slim AS runner
 
 WORKDIR /app
 
-COPY --from=builderrs /app/target/release/build ./build
-COPY --from=builderrs /app/target/release/koko ./koko
+COPY --from=builderrs /app/target/release/build ./target/release/build
+COPY --from=builderrs /app/target/release/koko ./target/release/koko
 COPY --from=builderrs /app/data ./data
 COPY --from=builderrs /app/checkpoints ./checkpoints
 
-RUN chmod +x ./koko && apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev 
+RUN chmod +x ./target/release/koko && apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev 
 
 EXPOSE 3000
 
-ENTRYPOINT [ "./koko" ]
+ENTRYPOINT [ "./target/release/koko" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,7 @@
 # syntax=docker/dockerfile:1
+FROM rust:1.86.0-slim-bookworm AS builderrs
 
-FROM python:3.12 AS builderpy
-
-COPY /scripts/fetch_voices.py .
-
-ADD https://huggingface.co/hexgrad/kLegacy/resolve/main/v0.19/kokoro-v0_19.onnx .
-
-RUN pip install requests torch numpy && python fetch_voices.py
-
-
-FROM rust:1.84.0-slim-bookworm AS builderrs
-
-RUN apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev clang git cmake && rustup component add rustfmt
+RUN apt-get update -qq && apt-get install -qq -y wget pkg-config libssl-dev clang git cmake && rustup component add rustfmt
 
 WORKDIR /app
 
@@ -20,19 +10,19 @@ COPY Cargo.toml .
 COPY Cargo.lock .
 
 RUN cargo build --release
+RUN chmod +x ./download_all.sh && ./download_all.sh
 
-
-FROM debian:bookworm-slim AS runner
+FROM debian:sid-slim AS runner
 
 WORKDIR /app
 
-COPY --from=builderrs /app/target/release/build ./target/release/build
-COPY --from=builderrs /app/target/release/koko ./target/release/koko
-COPY --from=builderpy /data ./data
-COPY --from=builderpy /kokoro-v0_19.onnx ./checkpoints/kokoro-v0_19.onnx
+COPY --from=builderrs /app/target/release/build ./build
+COPY --from=builderrs /app/target/release/koko ./koko
+COPY --from=builderrs /app/data ./data
+COPY --from=builderrs /app/checkpoints ./checkpoints
 
-RUN chmod +x ./target/release/koko && apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev 
+RUN chmod +x ./koko && apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev 
 
 EXPOSE 3000
 
-ENTRYPOINT [ "./target/release/koko" ] 
+ENTRYPOINT [ "./koko" ]


### PR DESCRIPTION
Model and Voice DL moved to builder, so that if eventually kokoros moves to rusttls instead of libssl, I believe the deployment image can just be a scratch container, if i'm not mistaken.

But mainly this fixes the issue that kokoros doesn't use the .py scripts anymore for downloading things, also the container base images were outdated.

Fixes #81 