### PR TITLE
Fix streaming by removing text from stdout

### DIFF
--- a/kokoros/src/tts/koko.rs
+++ b/kokoros/src/tts/koko.rs
@@ -180,7 +180,7 @@ impl TTSKoko {
             let phonemes = text_to_phonemes(&chunk, lan, None, true, false)
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?
                 .join("");
-            println!("phonemes: {}", phonemes);
+            eprintln!("phonemes: {}", phonemes);
             let mut tokens = tokenize(&phonemes);
 
             for _ in 0..initial_silence.unwrap_or(0) {
@@ -333,7 +333,7 @@ impl TTSKoko {
             voices
         };
 
-        println!("voice styles loaded: {:?}", sorted_voices);
+        eprintln!("voice styles loaded: {:?}", sorted_voices);
         map
     }
 }


### PR DESCRIPTION
Currently streaming is broken because the process writes text to stdout which can not be interpreted as wav data. This produces nasty hissing noises.

How I tested it on MacOS:
```
brew install sox
echo "Hello world" | ./target/release/koko -s af_heart stream | play -t wav -
```