### PR TITLE
Update README installation instructions to fix IoError

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This will copy the `koko` binary to `/usr/local/bin` (making it available system
 ### Generate speech for some text
 
 ```
+mkdir -p tmp
 ./target/release/koko text "Hello, this is a TTS test"
 ```
 


### PR DESCRIPTION
If the output option is not specified, the wav file is written to the tmp directory by default.
However, this directory is not created automatically, which results in the following error:
```
Error: IoError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```