### PR TITLE
Implement Ogg/Opus output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1093,8 @@ dependencies = [
  "mp3lame-encoder",
  "ndarray",
  "ndarray-npy",
+ "ogg",
+ "opus",
  "ort",
  "regex",
  "reqwest",
@@ -1384,6 +1397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1459,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opus"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6526409b274a7e98e55ff59d96aafd38e6cd34d46b7dbbc32ce126dffcd75e8e"
+dependencies = [
+ "audiopus_sys",
+ "libc",
 ]
 
 [[package]]

--- a/kokoros/Cargo.toml
+++ b/kokoros/Cargo.toml
@@ -17,6 +17,8 @@ ndarray-npy = "0.9.1"
 mp3lame-encoder = "0.2.1"
 tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"] }
+opus = "0.3"
+ogg = "0.9"
 
 # Base ONNX Runtime configuration
 ort = { version = "2.0.0-rc.10", default-features = true }

--- a/kokoros/src/utils/mod.rs
+++ b/kokoros/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod debug;
 pub mod fileio;
 pub mod mp3;
+pub mod opus;
 pub mod wav;

--- a/kokoros/src/utils/opus.rs
+++ b/kokoros/src/utils/opus.rs
@@ -1,0 +1,111 @@
+use opus::{Encoder, Channels, Application, Bitrate};
+use ogg::{PacketWriter, PacketWriteEndInfo};
+use std::io::Cursor;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn pcm_to_opus_ogg(pcm_data: &[f32], sample_rate: u32) -> Result<Vec<u8>, std::io::Error> {
+    // 1. Initialize Opus encoder with Audio application (better for high quality TTS)
+    let mut encoder = Encoder::new(sample_rate, Channels::Mono, Application::Audio)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Encoder init failed: {:?}", e)))?;
+
+    encoder.set_bitrate(Bitrate::Bits(64000))
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Set bitrate failed: {:?}", e)))?;
+
+    // Get strict pre-skip value from the encoder
+    let pre_skip = encoder.get_lookahead()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Get lookahead failed: {:?}", e)))? as u16;
+
+    // output buffer
+    let mut ogg_buffer = Cursor::new(Vec::new());
+    let mut packet_writer = PacketWriter::new(&mut ogg_buffer);
+
+    let serial_no = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(1);
+
+    // --- 2. Create header packet into OpusHead ---
+    let mut id_header = Vec::new();
+    id_header.extend_from_slice(b"OpusHead");
+    id_header.push(1); // Version
+    id_header.push(1); // Channels
+    id_header.extend_from_slice(&pre_skip.to_le_bytes()); // Pre-skip (Corrected)
+    id_header.extend_from_slice(&sample_rate.to_le_bytes()); // Input Sample Rate
+    id_header.extend_from_slice(&0u16.to_le_bytes()); // Gain
+    id_header.push(0); // Mapping Family
+
+    packet_writer.write_packet(id_header, serial_no, PacketWriteEndInfo::EndPage, 0)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    // --- 3. Create comment header into OpusTags ---
+    let comments = vec![
+        ("TITLE", "Generated Audio"),
+        ("ENCODER", "Kokoros TTS"),
+    ];
+    
+    let mut comment_header = Vec::new();
+    comment_header.extend_from_slice(b"OpusTags");
+    
+    let vendor = b"Rust Opus Encoder";
+    comment_header.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    comment_header.extend_from_slice(vendor);
+
+    comment_header.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+
+    for (key, value) in comments {
+        let comment_str = format!("{}={}", key, value);
+        let comment_bytes = comment_str.as_bytes();
+        comment_header.extend_from_slice(&(comment_bytes.len() as u32).to_le_bytes());
+        comment_header.extend_from_slice(comment_bytes);
+    }
+
+    packet_writer.write_packet(comment_header, serial_no, PacketWriteEndInfo::EndPage, 0)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    // --- 4. Encode audio data ---
+    let frame_size = (sample_rate as usize * 20) / 1000; // 20ms frames
+    // Output buffer recommendation: 4000 bytes is generally enough for max Opus frame
+    let mut output_buffer = vec![0u8; 4000];
+    
+    let chunks: Vec<&[f32]> = pcm_data.chunks(frame_size).collect();
+    let total_chunks = chunks.len();
+    let mut samples_processed: u64 = 0; // Track total input samples to avoid drift
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let is_last_chunk = i == total_chunks - 1;
+
+        // Padding for last chunk
+        let input_frame = if chunk.len() < frame_size {
+            let mut padded = chunk.to_vec();
+            padded.resize(frame_size, 0.0);
+            std::borrow::Cow::Owned(padded)
+        } else {
+            std::borrow::Cow::Borrowed(*chunk)
+        };
+
+        let encoded_len = encoder.encode_float(&input_frame, &mut output_buffer)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Encoding failed: {:?}", e)))?;
+
+        // Calculate Granule Position based on TOTAL processed input samples
+        // This avoids floating point accumulation errors.
+        // Formula: GP = (Total Input Samples * 48000) / Input Sample Rate
+        samples_processed += chunk.len() as u64;
+        
+        let granule_pos = (samples_processed * 48000) / sample_rate as u64;
+
+        let end_info = if is_last_chunk {
+            PacketWriteEndInfo::EndStream
+        } else {
+            PacketWriteEndInfo::NormalPacket
+        };
+
+        let packet_data = output_buffer[..encoded_len].to_vec();
+
+        packet_writer.write_packet(packet_data, serial_no, end_info, granule_pos)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    }
+
+    drop(packet_writer);
+
+    Ok(ogg_buffer.into_inner())
+}


### PR DESCRIPTION
Here is an example curl command for generating non-streaming Ogg/Opus output using the OpenAI mode:
```bash
$ curl -X POST http://localhost:3000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "tts-1",
    "input": "Hello, this is a test of the Kokoro TTS system!",
    "voice": "af_sky",
    "response_format": "opus",
    "stream": false
  }' \
  --output sky-says-hello.opus
  ```

And here is the validation result for the generated Opus file.
```bash
$ opusinfo sky-says-hello.opus # sudo apt install opus-tools
Processing file "sky-says-hello.opus"...

New logical stream (#1, serial: 17c75962): type opus
Encoded with Rust Opus Encoder
User comments section follows...
        TITLE=Generated Audio
        ENCODER=Kokoros TTS
Opus stream 1:
        Pre-skip: 156
        Playback gain: 0 dB
        Channels: 1
        Original sample rate: 24000Hz
        Packet duration:   20.0ms (max),   20.0ms (avg),   20.0ms (min)
        Page duration:   4100.0ms (max), 4100.0ms (avg), 4100.0ms (min)
        Total data length: 33237 bytes (overhead: 1.17%)
        Playback length: 0m:04.096s
        Average bitrate: 64.9 kb/s, w/o overhead: 64.14 kb/s
Logical stream 1 ended
```

Comparison of the generated file sizes when the input is "Hello, this is a test of the Kokoro TTS system!".
```bash
$ stat -c "%s %n" sky-says-hello.*
82276 sky-says-hello.mp3
33237 sky-says-hello.opus
196800 sky-says-hello.wav
```