### PR TITLE
Add GitHub Actions workflow to build and publish Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,43 @@
+name: Build and Push Docker Image to GHCR
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: kokoros
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/kokoros
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -232,10 +232,16 @@ echo "Suppose some other program was outputting lines of text" | ./target/releas
 
 ### With docker
 
-1. Build the image
+1. Build or Pull Docker Image
+
+You can either **build the Docker image locally** or **pull the pre-built image from GitHub Container Registry (GHCR)**.
 
 ```bash
+# Build locally
 docker build -t kokoros .
+
+# Or pull pre-built image from GHCR
+docker pull ghcr.io/lucasjinreal/kokoros:latest
 ```
 
 2. Run the image, passing options as described above


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow that automatically builds a Docker image using the existing Dockerfile and publishes it to the GitHub Container Registry. Whenever a commit is merged into the main branch, the Docker image will be automatically rebuilt and updated. Once built, the Docker image can be pulled from: ghcr.io/lucasjinreal/kokoros:latest.