### PR TITLE
Update Docker image tag from latest to main in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ You can either **build the Docker image locally** or **pull the pre-built image 
 docker build -t kokoros .
 
 # Or pull pre-built image from GHCR
-docker pull ghcr.io/lucasjinreal/kokoros:latest
+docker pull ghcr.io/lucasjinreal/kokoros:main
 ```
 
 2. Run the image, passing options as described above


### PR DESCRIPTION
The 'latest' tag no longer exists on GHCR. Pulling 'ghcr.io/lucasjinreal/kokoros:latest' fails,
so the README and instructions have been updated to use 'main' instead, which successfully pulls.

```bash
$ docker pull ghcr.io/lucasjinreal/kokoros:latest
Error response from daemon: manifest unknown

$ docker pull ghcr.io/lucasjinreal/kokoros:main
main: Pulling from lucasjinreal/kokoros
d817851450a8: Pull complete
8d0d49916cf1: Pull complete
06a00e7a0ea4: Pull complete
40b24f293c54: Pull complete
0084164fcca0: Pull complete
587249681e52: Pull complete
787dbcc49377: Pull complete
Digest: sha256:55f120f1922d65cbc21c1d4800ae06a6ec2b49d82ca48396c7c9a38b2367fee7
Status: Downloaded newer image for ghcr.io/lucasjinreal/kokoros:main
ghcr.io/lucasjinreal/kokoros:main
```