### PR TITLE
Support ONNX Timestamped model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ vendor/
 venv/
 .vscode/
 .worktrees/
+.idea/
+tmp/

--- a/README.md
+++ b/README.md
@@ -116,11 +116,73 @@ The generated audio will be saved to `tmp/output.wav` by default. You can custom
 ./target/release/koko file poem.txt
 ```
 
-For a file with 3 lines of text, by default, speech audio files `tmp/output_0.wav`, `tmp/output_1.wav`, `tmp/output_2.wav` will be outputted. You can customize the save location with the `--output` or `-o` option, using `{line}` as the line number:
+ For a file with 3 lines of text, by default, speech audio files `tmp/output_0.wav`, `tmp/output_1.wav`, `tmp/output_2.wav` will be outputted. You can customize the save location with the `--output` or `-o` option, using `{line}` as the line number:
 
 ```
 ./target/release/koko file lyrics.txt -o "song/lyric_{line}.wav"
 ```
+
+### Word-level timestamps (TSV sidecar)
+
+Add `--timestamps` to produce a `.tsv` file with per-word timings alongside the WAV output. The TSV contains three columns: `word`, `start_sec`, `end_sec`.
+
+Text mode example:
+
+```
+./target/release/koko text \
+  --output tmp/output.wav \
+  --timestamps \
+  "Hello from the timestamped model"
+```
+
+This creates:
+- `tmp/output.wav`
+- `tmp/output.tsv`
+
+File mode example (one pair per line):
+
+```
+./target/release/koko file input.txt \
+  --output tmp/line_{line}.wav \
+  --timestamps
+```
+
+For each line N, this creates `tmp/line_N.wav` and `tmp/line_N.tsv`.
+
+Notes:
+- The sidecar path is derived automatically by replacing the `.wav` extension with `.tsv`.
+- Sample rate is 24 kHz by default; times are in seconds with 3 decimal places.
+
+#### Quick start with the Hugging Face timestamped model (copy-paste)
+
+Copy and paste the following to run an end-to-end example using the timestamped Kokoro ONNX model hosted on Hugging Face. This will download the model and voice data to the expected paths and generate both `output.wav` and `output.tsv`.
+
+```
+mkdir -p checkpoints data tmp
+
+# 1) Download the timestamped ONNX model from Hugging Face
+curl -L \
+  "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX-timestamped/resolve/main/onnx/model.onnx" \
+  -o checkpoints/kokoro-v1.0.onnx
+
+# 2) Download voices data (single binary used by existing models)
+curl -L \
+  "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin" \
+  -o data/voices-v1.0.bin
+
+# 3) Build the binary
+cargo build --release
+
+# 4) Run: generates tmp/output.wav and tmp/output.tsv
+./target/release/koko text \
+  --output tmp/output.wav \
+  --timestamps \
+  "Hello from the timestamped model"
+```
+
+Notes:
+- We keep using the unified `voices-v1.0.bin`, which is compatible with the timestamped model.
+- If the files already exist in `checkpoints/` and `data/`, the CLI will use them directly.
 
 ### Parallel Processing Configuration
 

--- a/kokoros/src/onn/ort_koko.rs
+++ b/kokoros/src/onn/ort_koko.rs
@@ -5,28 +5,105 @@ use ort::{
     session::{Session, SessionInputValue, SessionInputs, SessionOutputs},
     value::{Tensor, Value},
 };
-
+use model_schema::v1_0_timestamped::DURATIONS;
 use super::ort_base;
 use ort_base::OrtBase;
 use crate::utils::debug::format_debug_prefix;
 
-pub struct OrtKoko {
-    sess: Option<Session>,
+mod model_schema {
+    pub const STYLE: &str = "style";
+    pub const SPEED: &str = "speed";
+
+    pub mod v1_0 {
+        pub const TOKENS: &str = "tokens";
+        pub const AUDIO: &str = "audio";
+    }
+
+    pub mod v1_0_timestamped {
+        pub const TOKENS: &str = "input_ids";
+        pub const AUDIO: &str = "waveform";
+        // We define primary and fallback keys as a const array
+        pub const DURATIONS: &str = "durations";
+    }
 }
-impl ort_base::OrtBase for OrtKoko {
+
+pub enum ModelStrategy {
+    Standard(Session),
+    Timestamped(Session),
+}
+
+pub struct OrtKoko {
+    inner: Option<ModelStrategy>,
+}
+
+impl ModelStrategy {
+    fn audio_key(&self) -> &'static str {
+        match self {
+            ModelStrategy::Standard(_) => model_schema::v1_0::AUDIO,
+            ModelStrategy::Timestamped(_) => model_schema::v1_0_timestamped::AUDIO,
+        }
+    }
+
+    fn tokens_key(&self) -> &'static str {
+        match self {
+            ModelStrategy::Standard(_) => model_schema::v1_0::TOKENS,
+            ModelStrategy::Timestamped(_) => model_schema::v1_0_timestamped::TOKENS,
+        }
+    }
+}
+
+impl OrtBase for OrtKoko {
     fn set_sess(&mut self, sess: Session) {
-        self.sess = Some(sess);
+        let output_count = sess.outputs.len();
+
+        let strategy = if output_count > 1 {
+            tracing::info!("OrtKoko: Timestamped backend activated ({} outputs)", output_count);
+            ModelStrategy::Timestamped(sess)
+        } else {
+            tracing::info!("OrtKoko: Standard backend activated ({} output)", output_count);
+            ModelStrategy::Standard(sess)
+        };
+
+        self.inner = Some(strategy);
     }
 
     fn sess(&self) -> Option<&Session> {
-        self.sess.as_ref()
+        self.inner.as_ref().map(|strategy| match strategy {
+            ModelStrategy::Standard(sess) => sess,
+            ModelStrategy::Timestamped(sess) => sess,
+        })
     }
 }
 impl OrtKoko {
     pub fn new(model_path: String) -> Result<Self, String> {
-        let mut instance = OrtKoko { sess: None };
+        let mut instance = OrtKoko { inner: None };
         instance.load_model(model_path)?;
         Ok(instance)
+    }
+
+    pub fn strategy(&self) -> Option<&ModelStrategy> {
+        self.inner.as_ref()
+    }
+
+    fn prepare_inputs(
+        tokens_key: &'static str,
+        tokens: Vec<Vec<i64>>,
+        styles: Vec<Vec<f32>>,
+        speed: f32,
+    ) -> Result<Vec<(Cow<'static, str>, SessionInputValue<'static>)>, Box<dyn std::error::Error>> {
+        let shape = [tokens.len(), tokens[0].len()];
+        let tokens_tensor = Tensor::from_array((shape, tokens.into_iter().flatten().collect::<Vec<i64>>()))?;
+
+        let shape_style = [styles.len(), styles[0].len()];
+        let style_tensor = Tensor::from_array((shape_style, styles.into_iter().flatten().collect::<Vec<f32>>()))?;
+
+        let speed_tensor = Tensor::from_array(([1], vec![speed]))?;
+
+        Ok(vec![
+            (Cow::Borrowed(tokens_key), SessionInputValue::Owned(Value::from(tokens_tensor))),
+            (Cow::Borrowed(model_schema::STYLE), SessionInputValue::Owned(Value::from(style_tensor))),
+            (Cow::Borrowed(model_schema::SPEED), SessionInputValue::Owned(Value::from(speed_tensor))),
+        ])
     }
 
     pub fn infer(
@@ -37,49 +114,52 @@ impl OrtKoko {
         request_id: Option<&str>,
         instance_id: Option<&str>,
         chunk_number: Option<usize>,
-    ) -> Result<ArrayBase<OwnedRepr<f32>, IxDyn>, Box<dyn std::error::Error>> {
+    ) -> Result<(ArrayBase<OwnedRepr<f32>, IxDyn>, Option<Vec<f32>>), Box<dyn std::error::Error>> {
 
-        let shape = [tokens.len(), tokens[0].len()];
-        let tokens_flat: Vec<i64> = tokens.into_iter().flatten().collect();
-        
         let debug_prefix = format_debug_prefix(request_id, instance_id);
         let chunk_info = chunk_number.map(|n| format!("Chunk: {}, ", n)).unwrap_or_default();
-        tracing::debug!("{} {}inference input: tokens_shape={:?}, tokens_count={}, styles_shape={:?}", debug_prefix, chunk_info, shape, tokens_flat.len(), [styles.len(), styles[0].len()]);
-        let tokens = Tensor::from_array((shape, tokens_flat))?;
-        let tokens_value: SessionInputValue = SessionInputValue::Owned(Value::from(tokens));
+        tracing::debug!("{} {}inference start. Tokens: {}", debug_prefix, chunk_info, tokens.len());
 
-        let shape_style = [styles.len(), styles[0].len()];
-        let style_flat: Vec<f32> = styles.into_iter().flatten().collect();
-        let style = Tensor::from_array((shape_style, style_flat))?;
-        let style_value: SessionInputValue = SessionInputValue::Owned(Value::from(style));
+        let strategy = self.inner.as_mut().ok_or("Session is not initialized.")?;
+        let audio_key = strategy.audio_key();
+        let tokens_key = strategy.tokens_key();
+        let inputs = Self::prepare_inputs(tokens_key, tokens.clone(), styles, speed)?;
+        match strategy {
+            ModelStrategy::Standard(sess) => {
+                let outputs = sess.run(SessionInputs::from(inputs))?;
 
-        let speed = vec![speed; 1];
-        let speed = Tensor::from_array(([1], speed))?;
-        let speed_value: SessionInputValue = SessionInputValue::Owned(Value::from(speed));
+                let (shape, data) = outputs[audio_key]
+                    .try_extract_tensor::<f32>()
+                    .or_else(|_| outputs["waveforms"].try_extract_tensor::<f32>())
+                    .map_err(|_| "Standard Model: Could not find 'audio' output")?;
 
-        let inputs: Vec<(Cow<str>, SessionInputValue)> = vec![
-            (Cow::Borrowed("tokens"), tokens_value),
-            (Cow::Borrowed("style"), style_value),
-            (Cow::Borrowed("speed"), speed_value),
-        ];
+                let shape_vec: Vec<usize> = shape.into_iter().map(|&i| i as usize).collect();
+                let audio_array = ArrayBase::from_shape_vec(shape_vec, data.to_vec())?;
 
-        if let Some(sess) = &mut self.sess {
-            let outputs: SessionOutputs = sess.run(SessionInputs::from(inputs))?;
-            let (shape, data) = outputs["audio"]
-                .try_extract_tensor::<f32>()
-                .expect("Failed to extract tensor");
+                Ok((audio_array, None))
+            }
+            ModelStrategy::Timestamped(sess) => {
+                let outputs = sess.run(SessionInputs::from(inputs))?;
 
-            // Convert Shape and &[f32] to ArrayBase<OwnedRepr<f32>, IxDyn>
-            let shape_vec: Vec<usize> = shape.into_iter().map(|&i| i as usize).collect();
-            let data_vec: Vec<f32> = data.to_vec();
-            let debug_prefix = format_debug_prefix(request_id, instance_id);
-            let chunk_info = chunk_number.map(|n| format!("Chunk: {}, ", n)).unwrap_or_default();
-            tracing::debug!("{} {}inference output: audio_shape={:?}, sample_count={}", debug_prefix, chunk_info, shape_vec, data_vec.len());
-            let output_array = ArrayBase::<OwnedRepr<f32>, IxDyn>::from_shape_vec(shape_vec, data_vec)?;
+                let (shape, data) = outputs[audio_key]
+                    .try_extract_tensor::<f32>()
+                    .or_else(|_| outputs["audio"].try_extract_tensor::<f32>())
+                    .map_err(|_| "Timestamped Model: Could not find 'waveforms' or 'audio'")?;
 
-            Ok(output_array)
-        } else {
-            Err("Session is not initialized.".into())
+                let shape_vec: Vec<usize> = shape.into_iter().map(|&i| i as usize).collect();
+                let audio_array = ArrayBase::from_shape_vec(shape_vec, data.to_vec())?;
+
+                let durations_vec = outputs[DURATIONS]
+                    .try_extract_tensor::<f32>()
+                    .map(|(_, d)| d.to_vec())
+                    .map_err(|_| format!(
+                        "Timestamped Model Error: Expected output tensor '{}' of type f32. \
+                        If your model uses 'duration' (singular) or i64, please update the schema constants.",
+                        DURATIONS
+                    ))?;
+
+                Ok((audio_array, Some(durations_vec)))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds support to ORT ONNX wrapper for the timestamped model from HF as well as refactors some of the repeated code in koko.rs. 

Please see the inline comments.

Currently, in order to maintain prosody naturalness and get timestamps at the word level, there's a tradeoff in latency as espeak has to be called once for the incoming sentences and then again per word. I am thinking of trimming this down in a following PR given the need for a MUTEX on espeak (:(). 

From testing on my Mac M3 Max, i'm getting ~10 words / sec throughput.

Note, if the loaded model doesn't support timestamps the performance will fallback to the original phoneme/tokenizing path so the hit only happens for timestamped models.

reference issue #98 
