### PR TITLE
Improve OpenAI Compatibility

### DIFF
--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -548,7 +548,7 @@ async fn handle_tts(
     let voice = voice.to_kokoro_voice();
 
     // OpenAI-compliant behavior: Stream by default, only send complete file if stream: false
-    let should_stream = stream.unwrap_or(true); // Default to streaming like OpenAI
+    let should_stream = stream.unwrap_or(false); // Default to not streaming
 
     let colored_request_id = get_colored_request_id_with_relative(&request_id, request_start);
     debug!(


### PR DESCRIPTION
First, it makes streaming off by default. The comments says that streaming is on by default in the OpenAI API, and that just isn't true in my experience (please correct me if I'm wrong). Regardless, running your example for standard audio generation (not streaming):
```bash
curl -X POST http://localhost:3000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "tts-1",
    "input": "Hello, this is a test of the Kokoro TTS system!",
    "voice": "af_sky"
  }' \
  --output sky-says-hello.wav
```
will result in a PCM file misformed as a .wav file. My disabling streaming by default, it will default to mp3, which plays much nicer with platforms.

Second, this adds a compatibility layer for the voices used in OpenAIs api to be mapped to voices in Kokoro. This improves compatibility with existing client side applications.

Third, similar to the second, this adds gpt-4o-mini-tts as a known model, increasing compatibility with existing OpenAI applications.