### PR TITLE
Add Nix flake for reproducible development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767754000,
+        "narHash": "sha256-znoNJs2QZFl+wCFLd6FbUJ00c74kvzOjyQYXc45uFvo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "0b3a5ad260479f2c9bdadf3ba5b2a4be359cfcdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "Kokoros - Rust TTS workspace";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
+
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          cmake
+        ];
+
+        buildInputs = with pkgs; [
+          # espeak-ng for espeak-rs
+          espeak-ng
+
+          # Audio encoding libraries
+          libopus
+          libogg
+          lame
+
+          # ONNX Runtime
+          onnxruntime
+
+          # OpenSSL for reqwest
+          openssl
+        ] ++ lib.optionals stdenv.isDarwin [
+          apple-sdk_15
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          inherit nativeBuildInputs buildInputs;
+
+          env = {
+            RUST_BACKTRACE = "1";
+            PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" buildInputs;
+            ORT_STRATEGY = "system";
+            ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
+          };
+
+          shellHook = ''
+            echo "Kokoros development shell"
+            echo "Rust: $(rustc --version)"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Kokoros has several native dependencies (espeak-ng, libopus, libogg, lame, onnxruntime, openssl) that can be tricky to set up correctly across different systems. This flake provides a declarative, reproducible development shell that works on both Linux and macOS.

Benefits for contributors:
- Single `nix develop` command sets up the entire build environment
- Pinned dependencies via flake.lock ensure consistent builds
- Eliminates "works on my machine" issues with native library versions
- Automatically configures PKG_CONFIG_PATH and ORT_LIB_LOCATION
- Includes rust-analyzer for IDE support out of the box