### PR TITLE
apply cargo fmt

### DIFF
--- a/kokoros/src/onn/ort_base.rs
+++ b/kokoros/src/onn/ort_base.rs
@@ -1,9 +1,9 @@
+use ort::execution_providers::cpu::CPUExecutionProvider;
 #[cfg(feature = "cuda")]
 use ort::execution_providers::cuda::CUDAExecutionProvider;
-use ort::execution_providers::cpu::CPUExecutionProvider;
-use ort::session::builder::SessionBuilder;
-use ort::session::Session;
 use ort::logging::LogLevel;
+use ort::session::Session;
+use ort::session::builder::SessionBuilder;
 
 pub trait OrtBase {
     fn load_model(&mut self, model_path: String) -> Result<(), String> {

--- a/kokoros/src/onn/ort_koko.rs
+++ b/kokoros/src/onn/ort_koko.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
 
+use super::ort_base;
+use crate::utils::debug::format_debug_prefix;
+use model_schema::v1_0_timestamped::DURATIONS;
 use ndarray::{ArrayBase, IxDyn, OwnedRepr};
 use ort::{
     session::{Session, SessionInputValue, SessionInputs, SessionOutputs},
     value::{Tensor, Value},
 };
-use model_schema::v1_0_timestamped::DURATIONS;
-use super::ort_base;
 use ort_base::OrtBase;
-use crate::utils::debug::format_debug_prefix;
 
 mod model_schema {
     pub const STYLE: &str = "style";
@@ -57,10 +57,16 @@ impl OrtBase for OrtKoko {
         let output_count = sess.outputs.len();
 
         let strategy = if output_count > 1 {
-            tracing::info!("OrtKoko: Timestamped backend activated ({} outputs)", output_count);
+            tracing::info!(
+                "OrtKoko: Timestamped backend activated ({} outputs)",
+                output_count
+            );
             ModelStrategy::Timestamped(sess)
         } else {
-            tracing::info!("OrtKoko: Standard backend activated ({} output)", output_count);
+            tracing::info!(
+                "OrtKoko: Standard backend activated ({} output)",
+                output_count
+            );
             ModelStrategy::Standard(sess)
         };
 
@@ -90,19 +96,33 @@ impl OrtKoko {
         tokens: Vec<Vec<i64>>,
         styles: Vec<Vec<f32>>,
         speed: f32,
-    ) -> Result<Vec<(Cow<'static, str>, SessionInputValue<'static>)>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<(Cow<'static, str>, SessionInputValue<'static>)>, Box<dyn std::error::Error>>
+    {
         let shape = [tokens.len(), tokens[0].len()];
-        let tokens_tensor = Tensor::from_array((shape, tokens.into_iter().flatten().collect::<Vec<i64>>()))?;
+        let tokens_tensor =
+            Tensor::from_array((shape, tokens.into_iter().flatten().collect::<Vec<i64>>()))?;
 
         let shape_style = [styles.len(), styles[0].len()];
-        let style_tensor = Tensor::from_array((shape_style, styles.into_iter().flatten().collect::<Vec<f32>>()))?;
+        let style_tensor = Tensor::from_array((
+            shape_style,
+            styles.into_iter().flatten().collect::<Vec<f32>>(),
+        ))?;
 
         let speed_tensor = Tensor::from_array(([1], vec![speed]))?;
 
         Ok(vec![
-            (Cow::Borrowed(tokens_key), SessionInputValue::Owned(Value::from(tokens_tensor))),
-            (Cow::Borrowed(model_schema::STYLE), SessionInputValue::Owned(Value::from(style_tensor))),
-            (Cow::Borrowed(model_schema::SPEED), SessionInputValue::Owned(Value::from(speed_tensor))),
+            (
+                Cow::Borrowed(tokens_key),
+                SessionInputValue::Owned(Value::from(tokens_tensor)),
+            ),
+            (
+                Cow::Borrowed(model_schema::STYLE),
+                SessionInputValue::Owned(Value::from(style_tensor)),
+            ),
+            (
+                Cow::Borrowed(model_schema::SPEED),
+                SessionInputValue::Owned(Value::from(speed_tensor)),
+            ),
         ])
     }
 
@@ -114,11 +134,18 @@ impl OrtKoko {
         request_id: Option<&str>,
         instance_id: Option<&str>,
         chunk_number: Option<usize>,
-    ) -> Result<(ArrayBase<OwnedRepr<f32>, IxDyn>, Option<Vec<f32>>), Box<dyn std::error::Error>> {
-
+    ) -> Result<(ArrayBase<OwnedRepr<f32>, IxDyn>, Option<Vec<f32>>), Box<dyn std::error::Error>>
+    {
         let debug_prefix = format_debug_prefix(request_id, instance_id);
-        let chunk_info = chunk_number.map(|n| format!("Chunk: {}, ", n)).unwrap_or_default();
-        tracing::debug!("{} {}inference start. Tokens: {}", debug_prefix, chunk_info, tokens.len());
+        let chunk_info = chunk_number
+            .map(|n| format!("Chunk: {}, ", n))
+            .unwrap_or_default();
+        tracing::debug!(
+            "{} {}inference start. Tokens: {}",
+            debug_prefix,
+            chunk_info,
+            tokens.len()
+        );
 
         let strategy = self.inner.as_mut().ok_or("Session is not initialized.")?;
         let audio_key = strategy.audio_key();

--- a/kokoros/src/tts/koko.rs
+++ b/kokoros/src/tts/koko.rs
@@ -42,7 +42,7 @@ impl TtsOutput {
     pub fn raw_output(self) -> (Vec<f32>, Option<Vec<WordAlignment>>) {
         match self {
             TtsOutput::Audio(a) => (a, None),
-            TtsOutput::Aligned(a, b) => (a, Some(b))
+            TtsOutput::Aligned(a, b) => (a, Some(b)),
         }
     }
 }
@@ -148,14 +148,14 @@ impl TTSKoko {
         chunk_number_start: Option<usize>,
         mut mode: ExecutionMode,
     ) -> Result<Option<(Vec<f32>, Vec<WordAlignment>)>, Box<dyn std::error::Error>> {
-
         let chunks = self.split_text_into_chunks(txt, 500, lan);
         let start_chunk_num = chunk_number_start.unwrap_or(0);
 
         let debug_prefix = format_debug_prefix(request_id, instance_id);
 
-        let process_one_chunk = |chunk: &str, chunk_num: usize| -> Result<TtsOutput, Box<dyn std::error::Error>> {
-
+        let process_one_chunk = |chunk: &str,
+                                 chunk_num: usize|
+         -> Result<TtsOutput, Box<dyn std::error::Error>> {
             let chunk_info = format!("Chunk: {}, ", chunk_num);
             tracing::debug!("{} {}text: '{}'", debug_prefix, chunk_info, chunk);
 
@@ -174,7 +174,12 @@ impl TTSKoko {
             };
 
             // Log token count (helpful for debugging context limits)
-            tracing::debug!("{} {}tokens generated: {}", debug_prefix, chunk_info, tokens.len());
+            tracing::debug!(
+                "{} {}tokens generated: {}",
+                debug_prefix,
+                chunk_info,
+                tokens.len()
+            );
 
             // B. Silence
             let silence_count = initial_silence.unwrap_or(0);
@@ -232,9 +237,9 @@ impl TTSKoko {
                 let punct_pause_s = |label: &str| -> f32 {
                     match label {
                         "." | "!" | "?" => 0.300, // 300 ms
-                        ","                 => 0.150, // 150 ms
-                        ";" | ":"           => 0.200,
-                        _                    => 0.0,
+                        "," => 0.150,             // 150 ms
+                        ";" | ":" => 0.200,
+                        _ => 0.0,
                     }
                 };
 
@@ -250,7 +255,11 @@ impl TTSKoko {
                         let pause_frames = pause_s * frames_per_sec;
                         let start_sec = chunk_time_cursor_frames / frames_per_sec;
                         let end_sec = (chunk_time_cursor_frames + pause_frames) / frames_per_sec;
-                        alignments.push(WordAlignment { word: word.clone(), start_sec, end_sec });
+                        alignments.push(WordAlignment {
+                            word: word.clone(),
+                            start_sec,
+                            end_sec,
+                        });
                         chunk_time_cursor_frames += pause_frames;
                         continue;
                     }
@@ -265,7 +274,11 @@ impl TTSKoko {
 
                         let start_sec = chunk_time_cursor_frames / frames_per_sec;
                         let end_sec = (chunk_time_cursor_frames + word_frames) / frames_per_sec;
-                        alignments.push(WordAlignment { word, start_sec, end_sec });
+                        alignments.push(WordAlignment {
+                            word,
+                            start_sec,
+                            end_sec,
+                        });
                         chunk_time_cursor_frames += word_frames;
                     }
                 }
@@ -279,11 +292,15 @@ impl TTSKoko {
                     let s = (chunk_audio_sec / t_end_sec);
                     // Optionally clamp extreme corrections; typical values should be close to 1.0
                     let s_clamped = s.clamp(0.8, 1.25);
-                    if (s_clamped - 1.0).abs() > 0.005 { // >0.5% correction
-                        tracing::debug!(scale = s_clamped, "Per-chunk alignment scaling applied (speed-aware)");
+                    if (s_clamped - 1.0).abs() > 0.005 {
+                        // >0.5% correction
+                        tracing::debug!(
+                            scale = s_clamped,
+                            "Per-chunk alignment scaling applied (speed-aware)"
+                        );
                         for al in &mut alignments {
                             al.start_sec *= s_clamped;
-                            al.end_sec   *= s_clamped;
+                            al.end_sec *= s_clamped;
                         }
                     }
 
@@ -291,17 +308,17 @@ impl TTSKoko {
                     let diff_ms = (((t_end_sec * s_clamped) - chunk_audio_sec) * 1000.0).abs();
                     if diff_ms > 10.0 {
                         tracing::warn!(
-                chunk_t_end_sec = t_end_sec * s_clamped,
-                chunk_audio_sec,
-                diff_ms,
-                "Alignment vs audio duration still off after scaling",
-            );
+                            chunk_t_end_sec = t_end_sec * s_clamped,
+                            chunk_audio_sec,
+                            diff_ms,
+                            "Alignment vs audio duration still off after scaling",
+                        );
                     } else {
                         tracing::debug!(
-                chunk_t_end_sec = t_end_sec * s_clamped,
-                chunk_audio_sec,
-                "Chunk alignment closure OK",
-            );
+                            chunk_t_end_sec = t_end_sec * s_clamped,
+                            chunk_audio_sec,
+                            "Chunk alignment closure OK",
+                        );
                     }
                 }
 
@@ -354,7 +371,11 @@ impl TTSKoko {
     }
 
     /// Prosody-Aware Tokenization ---
-    fn tokenize_with_alignment(&self, text: &str, lan: &str) -> (Vec<i64>, Vec<(String, usize, usize)>) {
+    fn tokenize_with_alignment(
+        &self,
+        text: &str,
+        lan: &str,
+    ) -> (Vec<i64>, Vec<(String, usize, usize)>) {
         // We will produce tokens from the full, context-aware phonemes (best prosody)
         // and build an alignment map by estimating per-word token spans using
         // per-word phoneme tokenization. This keeps audio natural while providing
@@ -455,11 +476,18 @@ impl TTSKoko {
             let mut remaining = target_len.saturating_sub(new_sum);
             fractional.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
             for (i, _) in fractional {
-                if remaining == 0 { break; }
+                if remaining == 0 {
+                    break;
+                }
                 adjusted_counts[i] += 1;
                 remaining -= 1;
             }
-            tracing::debug!("Alignment: rescaled per-item token counts from {} to {} to match durations length {}.", sum_counts, adjusted_counts.iter().sum::<usize>(), target_len);
+            tracing::debug!(
+                "Alignment: rescaled per-item token counts from {} to {} to match durations length {}.",
+                sum_counts,
+                adjusted_counts.iter().sum::<usize>(),
+                target_len
+            );
             sum_counts = adjusted_counts.iter().sum();
         }
 
@@ -482,7 +510,9 @@ impl TTSKoko {
 
         // If our mapping under-ran due to rounding issues, extend the last non-punct item to cover all tokens
         if cursor < target_len {
-            if let Some(last_non_punct_pos) = (0..word_map.len()).rev().find(|&i| !(per_item_is_punct[i])) {
+            if let Some(last_non_punct_pos) =
+                (0..word_map.len()).rev().find(|&i| !(per_item_is_punct[i]))
+            {
                 let (w, s, _e) = &word_map[last_non_punct_pos];
                 word_map[last_non_punct_pos] = (w.clone(), *s, target_len);
             }
@@ -494,7 +524,11 @@ impl TTSKoko {
 
     /// Fast tokenization path for audio-only models (no timestamps)
     /// Performs a single eSpeak phonemization for the full text and returns tokens with an empty word map.
-    fn tokenize_full_no_alignment(&self, text: &str, lan: &str) -> (Vec<i64>, Vec<(String, usize, usize)>) {
+    fn tokenize_full_no_alignment(
+        &self,
+        text: &str,
+        lan: &str,
+    ) -> (Vec<i64>, Vec<(String, usize, usize)>) {
         let full_phonemes = {
             let _guard = ESPEAK_MUTEX.lock().unwrap();
             text_to_phonemes(text, lan, None, true, false)
@@ -727,7 +761,7 @@ impl TTSKoko {
             request_id,
             instance_id,
             chunk_number,
-            ExecutionMode::Batch
+            ExecutionMode::Batch,
         )
     }
 
@@ -808,7 +842,7 @@ impl TTSKoko {
         mut chunk_callback: F,
     ) -> Result<(), Box<dyn std::error::Error>>
     where
-    // CHANGE: Callback accepts TtsOutput instead of just Vec<f32>
+        // CHANGE: Callback accepts TtsOutput instead of just Vec<f32>
         F: FnMut((Vec<f32>, Vec<WordAlignment>)) -> Result<(), Box<dyn std::error::Error>>,
     {
         let mut adapter = |output: TtsOutput| -> Result<(), Box<dyn std::error::Error>> {
@@ -1107,7 +1141,14 @@ impl TTSKokoParallel {
     ) -> Result<Option<(Vec<f32>, Vec<WordAlignment>)>, Box<dyn Error>> {
         let wrapper = self.get_tts_wrapper(model_instance);
         wrapper.tts_timestamped_raw_audio(
-            text, language, style_name, speed, initial_silence, request_id, instance_id, chunk_number
+            text,
+            language,
+            style_name,
+            speed,
+            initial_silence,
+            request_id,
+            instance_id,
+            chunk_number,
         )
     }
 
@@ -1127,8 +1168,14 @@ impl TTSKokoParallel {
         let wrapper = self.get_tts_wrapper(model_instance);
 
         wrapper.tts_raw_audio(
-            text, language, style_name, speed,
-            initial_silence, request_id, instance_id, chunk_number
+            text,
+            language,
+            style_name,
+            speed,
+            initial_silence,
+            request_id,
+            instance_id,
+            chunk_number,
         )
     }
 

--- a/kokoros/src/utils/debug.rs
+++ b/kokoros/src/utils/debug.rs
@@ -1,10 +1,9 @@
 use std::time::Instant;
 
-// ANSI color codes for request ID colorization  
+// ANSI color codes for request ID colorization
 const COLORS: &[&str] = &[
-    "\x1b[31m", "\x1b[32m", "\x1b[33m", "\x1b[34m", "\x1b[35m", "\x1b[36m",
-    "\x1b[91m", "\x1b[92m", "\x1b[93m", "\x1b[94m", "\x1b[95m", "\x1b[96m",
-    "\x1b[37m", "\x1b[90m"
+    "\x1b[31m", "\x1b[32m", "\x1b[33m", "\x1b[34m", "\x1b[35m", "\x1b[36m", "\x1b[91m", "\x1b[92m",
+    "\x1b[93m", "\x1b[94m", "\x1b[95m", "\x1b[96m", "\x1b[37m", "\x1b[90m",
 ];
 const RESET: &str = "\x1b[0m";
 
@@ -24,11 +23,11 @@ pub fn format_debug_prefix(request_id: Option<&str>, instance_id: Option<&str>) 
         (Some(req_id), Some(inst_id)) => {
             let color = get_request_id_color(req_id);
             format!("{}[{}]{}[{}]", color, req_id, RESET, inst_id)
-        },
+        }
         (Some(req_id), None) => {
             let color = get_request_id_color(req_id);
             format!("{}[{}]{}", color, req_id, RESET)
-        },
+        }
         (None, Some(inst_id)) => format!("[{}]", inst_id),
         (None, None) => String::new(),
     }
@@ -37,14 +36,17 @@ pub fn format_debug_prefix(request_id: Option<&str>, instance_id: Option<&str>) 
 /// Get colored request ID with relative timing (enhanced version)
 pub fn get_colored_request_id_with_relative(request_id: &str, start_time: Instant) -> String {
     let color = get_request_id_color(request_id);
-    
+
     // Get relative time from request start
     let elapsed_ms = start_time.elapsed().as_millis();
     let relative_time = if elapsed_ms < 1 {
-        "    0".to_string()  // Show "0" right-aligned for initial request
+        "    0".to_string() // Show "0" right-aligned for initial request
     } else {
-        format!("{:5}", elapsed_ms)  // Right-aligned 5 digits
+        format!("{:5}", elapsed_ms) // Right-aligned 5 digits
     };
-    
-    format!("{}[{}]{} \x1b[90m{}\x1b[0m", color, request_id, RESET, relative_time)
+
+    format!(
+        "{}[{}]{} \x1b[90m{}\x1b[0m",
+        color, request_id, RESET, relative_time
+    )
 }

--- a/kokoros/src/utils/opus.rs
+++ b/kokoros/src/utils/opus.rs
@@ -1,19 +1,32 @@
-use opus::{Encoder, Channels, Application, Bitrate};
-use ogg::{PacketWriter, PacketWriteEndInfo};
+use ogg::{PacketWriteEndInfo, PacketWriter};
+use opus::{Application, Bitrate, Channels, Encoder};
 use std::io::Cursor;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn pcm_to_opus_ogg(pcm_data: &[f32], sample_rate: u32) -> Result<Vec<u8>, std::io::Error> {
     // 1. Initialize Opus encoder with Audio application (better for high quality TTS)
-    let mut encoder = Encoder::new(sample_rate, Channels::Mono, Application::Audio)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Encoder init failed: {:?}", e)))?;
+    let mut encoder =
+        Encoder::new(sample_rate, Channels::Mono, Application::Audio).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Encoder init failed: {:?}", e),
+            )
+        })?;
 
-    encoder.set_bitrate(Bitrate::Bits(64000))
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Set bitrate failed: {:?}", e)))?;
+    encoder.set_bitrate(Bitrate::Bits(64000)).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Set bitrate failed: {:?}", e),
+        )
+    })?;
 
     // Get strict pre-skip value from the encoder
-    let pre_skip = encoder.get_lookahead()
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Get lookahead failed: {:?}", e)))? as u16;
+    let pre_skip = encoder.get_lookahead().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Get lookahead failed: {:?}", e),
+        )
+    })? as u16;
 
     // output buffer
     let mut ogg_buffer = Cursor::new(Vec::new());
@@ -34,18 +47,16 @@ pub fn pcm_to_opus_ogg(pcm_data: &[f32], sample_rate: u32) -> Result<Vec<u8>, st
     id_header.extend_from_slice(&0u16.to_le_bytes()); // Gain
     id_header.push(0); // Mapping Family
 
-    packet_writer.write_packet(id_header, serial_no, PacketWriteEndInfo::EndPage, 0)
+    packet_writer
+        .write_packet(id_header, serial_no, PacketWriteEndInfo::EndPage, 0)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     // --- 3. Create comment header into OpusTags ---
-    let comments = vec![
-        ("TITLE", "Generated Audio"),
-        ("ENCODER", "Kokoros TTS"),
-    ];
-    
+    let comments = vec![("TITLE", "Generated Audio"), ("ENCODER", "Kokoros TTS")];
+
     let mut comment_header = Vec::new();
     comment_header.extend_from_slice(b"OpusTags");
-    
+
     let vendor = b"Rust Opus Encoder";
     comment_header.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
     comment_header.extend_from_slice(vendor);
@@ -59,14 +70,15 @@ pub fn pcm_to_opus_ogg(pcm_data: &[f32], sample_rate: u32) -> Result<Vec<u8>, st
         comment_header.extend_from_slice(comment_bytes);
     }
 
-    packet_writer.write_packet(comment_header, serial_no, PacketWriteEndInfo::EndPage, 0)
+    packet_writer
+        .write_packet(comment_header, serial_no, PacketWriteEndInfo::EndPage, 0)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     // --- 4. Encode audio data ---
     let frame_size = (sample_rate as usize * 20) / 1000; // 20ms frames
     // Output buffer recommendation: 4000 bytes is generally enough for max Opus frame
     let mut output_buffer = vec![0u8; 4000];
-    
+
     let chunks: Vec<&[f32]> = pcm_data.chunks(frame_size).collect();
     let total_chunks = chunks.len();
     let mut samples_processed: u64 = 0; // Track total input samples to avoid drift
@@ -83,14 +95,20 @@ pub fn pcm_to_opus_ogg(pcm_data: &[f32], sample_rate: u32) -> Result<Vec<u8>, st
             std::borrow::Cow::Borrowed(*chunk)
         };
 
-        let encoded_len = encoder.encode_float(&input_frame, &mut output_buffer)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Encoding failed: {:?}", e)))?;
+        let encoded_len = encoder
+            .encode_float(&input_frame, &mut output_buffer)
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Encoding failed: {:?}", e),
+                )
+            })?;
 
         // Calculate Granule Position based on TOTAL processed input samples
         // This avoids floating point accumulation errors.
         // Formula: GP = (Total Input Samples * 48000) / Input Sample Rate
         samples_processed += chunk.len() as u64;
-        
+
         let granule_pos = (samples_processed * 48000) / sample_rate as u64;
 
         let end_info = if is_last_chunk {
@@ -101,7 +119,8 @@ pub fn pcm_to_opus_ogg(pcm_data: &[f32], sample_rate: u32) -> Result<Vec<u8>, st
 
         let packet_data = output_buffer[..encoded_len].to_vec();
 
-        packet_writer.write_packet(packet_data, serial_no, end_info, granule_pos)
+        packet_writer
+            .write_packet(packet_data, serial_no, end_info, granule_pos)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     }
 


### PR DESCRIPTION
Rust-Analyzer was auto formatting things to match cargo fmt, which made cutting a clean PR for https://github.com/lucasjinreal/Kokoros/pull/115 very annoying :)

Completely understand if you don't want to merge this, but figured it would be easier to just give you a PR vs creating an issue asking.