### PR TITLE
Add Nix flake for reproducible development environment (with CUDA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ or with CUDA support:
 
 ```bash
 nix develop .#cuda
-cargo build --release
+cargo build --features kokoros/cuda --release
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ bash install.sh
 
 This will copy the `koko` binary to `/usr/local/bin` (making it available system-wide as `koko`) and copy the voice data to `$HOME/.cache/kokoros/`.
 
+## Build using Nix
+
+```bash
+nix develop
+cargo build --release
+```
+
+or with CUDA support:
+
+```bash
+nix develop .#cuda
+cargo build --release
+```
+
 ## Usage
 
 ### View available options

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767754000,
+        "narHash": "sha256-znoNJs2QZFl+wCFLd6FbUJ00c74kvzOjyQYXc45uFvo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "0b3a5ad260479f2c9bdadf3ba5b2a4be359cfcdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,108 @@
+{
+  description = "Kokoros - Rust TTS workspace";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.allowUnfree = true; # Required for CUDA
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
+
+        # ONNX Runtime with CUDA support
+        onnxruntimeCuda = pkgs.onnxruntime.override {
+          cudaSupport = true;
+        };
+
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          cmake
+          llvmPackages.libclang
+          gcc
+          alsa-utils
+        ];
+
+        commonBuildInputs = with pkgs; [
+          # espeak-ng for espeak-rs
+          espeak-ng
+
+          # Audio encoding libraries
+          libopus
+          libogg
+          lame
+
+          # OpenSSL for reqwest
+          openssl
+        ] ++ lib.optionals stdenv.isDarwin [
+          apple-sdk_15
+        ];
+
+        buildInputs = commonBuildInputs ++ [ pkgs.onnxruntime ];
+        buildInputsCuda = commonBuildInputs ++ [ onnxruntimeCuda ];
+
+        commonEnv = {
+          RUST_BACKTRACE = "1";
+          PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" buildInputs;
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          BINDGEN_EXTRA_CLANG_ARGS = builtins.concatStringsSep " " [
+            "-I${pkgs.llvmPackages.libclang.lib}/lib/clang/${pkgs.llvmPackages.libclang.version}/include"
+            "-I${pkgs.glibc.dev}/include"
+          ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          inherit nativeBuildInputs buildInputs;
+
+          env = commonEnv // {
+            ORT_STRATEGY = "system";
+            ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
+            ORT_PREFER_DYNAMIC_LINK = "1";
+          };
+
+          shellHook = ''
+            echo "Kokoros development shell"
+            echo "Rust: $(rustc --version)"
+          '';
+        };
+
+        devShells.cuda = pkgs.mkShell {
+          nativeBuildInputs = nativeBuildInputs;
+          buildInputs = buildInputsCuda;
+
+          env = commonEnv // {
+            ORT_STRATEGY = "system";
+            ORT_LIB_LOCATION = "${onnxruntimeCuda}/lib";
+            ORT_PREFER_DYNAMIC_LINK = "1";
+            # Add CUDA to library path for runtime
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+              onnxruntimeCuda
+              pkgs.cudaPackages.cudatoolkit
+              pkgs.cudaPackages.cudnn
+            ];
+          };
+
+          shellHook = ''
+            echo "Kokoros development shell (CUDA enabled)"
+            echo "Rust: $(rustc --version)"
+            echo "CUDA: $(nvcc --version 2>/dev/null || echo 'not in PATH')"
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
           env = commonEnv // {
             # Use download strategy since nixpkgs onnxruntime (1.22.2) is too old for ort 2.0.0-rc.11 (needs 1.23+)
             ORT_STRATEGY = "download";
+            # Set RPATH to $ORIGIN so binaries can find ONNX Runtime libraries in the same directory
+            CARGO_BUILD_RUSTFLAGS = "-C link-arg=-Wl,-rpath,$ORIGIN";
           };
 
           shellHook = ''
@@ -80,6 +82,8 @@
           env = commonEnv // {
             # Use download strategy since nixpkgs onnxruntime (1.22.2) is too old for ort 2.0.0-rc.11 (needs 1.23+)
             ORT_STRATEGY = "download";
+            # Set RPATH to $ORIGIN so binaries can find ONNX Runtime libraries in the same directory
+            CARGO_BUILD_RUSTFLAGS = "-C link-arg=-Wl,-rpath,$ORIGIN";
             # Add CUDA to library path for runtime
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
               pkgs.cudaPackages.cudatoolkit


### PR DESCRIPTION
Based on @qmx 's [PR](https://github.com/lucasjinreal/Kokoros/pull/114) by I added a flake.nix with CUDA support.

Tested on NixOS.

Without CUDA:
```bash
nix develop
cargo build --release
```

With CUDA:
 ```bash
nix develop .#cuda
cargo build --release --features kokoros/cuda
```


## Tests

without CUDA:
```bash
nix develop
cargo clean && cargo build -r && ./target/release/koko openai

time curl -X POST http://localhost:3000/v1/audio/speech   -H "Content-Type: application/json"   -d '{
    "model": "tts-1",
    "input": "This is a streaming test with real-time audio generation.",
    "voice": "af_sky",
    "stream": true
  }'   --output streaming-audio.pcm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 199343   0 199200 100   143 639426   459  --:--:-- --:--:-- --:--:-- 640974

real	0m0.316s
```

With CUDA:
```bash
nix develop .#cuda
cargo clean && cargo build -r --features kokoros/cuda && ./target/release/koko openai

time curl -X POST http://localhost:3000/v1/audio/speech   -H "Content-Type: application/json"   -d '{
    "model": "tts-1",
    "input": "This is a streaming test with real-time audio generation.",
    "voice": "af_sky",
    "stream": true
  }'   --output streaming-audio.pcm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 199343   0 199200 100   143  1661k  1221  --:--:-- --:--:-- --:--:--  1663k

real	0m0.121s
```