### PR TITLE
Docker Build Linker Error Fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM rust:1.88.0-slim-trixie AS builderrs
 
-RUN apt-get update -qq && apt-get install -qq -y wget pkg-config libssl-dev clang git cmake && rustup component add rustfmt
+RUN apt-get update -qq && apt-get install -qq -y wget pkg-config libssl-dev clang git cmake libsonic-dev libpcaudio-dev && rustup component add rustfmt
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ COPY --from=builderrs /app/target/release/koko ./target/release/koko
 COPY --from=builderrs /app/data ./data
 COPY --from=builderrs /app/checkpoints ./checkpoints
 
-RUN chmod +x ./target/release/koko && apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev 
+RUN chmod +x ./target/release/koko && apt-get update -qq && apt-get install -qq -y pkg-config libssl-dev libsonic-dev libpcaudio-dev
 
 EXPOSE 3000
 

--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -379,6 +379,7 @@ struct SpeechRequest {
 }
 
 /// Async TTS worker task
+#[allow(dead_code)]
 #[derive(Debug)]
 struct TTSTask {
     id: usize,
@@ -390,6 +391,7 @@ struct TTSTask {
 }
 
 /// Streaming session manager
+#[allow(dead_code)]
 #[derive(Debug)]
 struct StreamingSession {
     session_id: Uuid,

--- a/kokoros/src/tts/koko.rs
+++ b/kokoros/src/tts/koko.rs
@@ -459,7 +459,7 @@ impl TTSKoko {
         //    If sums differ (likely due to coarticulation/context differences),
         //    rescale the counts to match the full length, keeping the distribution similar.
         let target_len = all_tokens.len();
-        let mut sum_counts: usize = per_item_token_counts.iter().sum();
+        let sum_counts: usize = per_item_token_counts.iter().sum();
 
         let mut adjusted_counts: Vec<usize> = per_item_token_counts.clone();
         if sum_counts != target_len && sum_counts > 0 {

--- a/kokoros/src/tts/phonemizer.rs
+++ b/kokoros/src/tts/phonemizer.rs
@@ -10,6 +10,7 @@ lazy_static! {
 }
 
 // Placeholder for the EspeakBackend struct
+#[allow(dead_code)]
 struct EspeakBackend {
     language: String,
     preserve_punctuation: bool,


### PR DESCRIPTION
The root cause was missing system libraries required by `espeak-rs-sys`. The build was failing with:

```
/usr/bin/ld: cannot find -lsonic: No such file or directory
/usr/bin/ld: cannot find -lpcaudio: No such file or directory
```

**Dockerfile changes:**
- Added `libsonic-dev` and `libpcaudio-dev` packages to the build stage
- Added `libsonic-dev` and `libpcaudio-dev` packages to the runner stage (for runtime)