### PR TITLE
fix(openai): use valid espeak id for British voices ('en-gb' is invalid)

### DIFF
--- a/kokoros-openai/src/lib.rs
+++ b/kokoros-openai/src/lib.rs
@@ -312,7 +312,10 @@ fn get_language_code(lang_code: Option<&str>, voice: &str) -> String {
             .unwrap();
         match prefix {
             'a' => "en-us",
-            'b' => "en-gb",
+            // British English voices: "en-gb" is not a valid espeak-ng voice id,
+            // so it produces empty phonemes -> near-empty audio. Use the RP British
+            // identifier that espeak-ng actually recognizes.
+            'b' => "en-gb-x-rp",
             'p' => "pt-br",
             'j' => "ja",
             'z' => "cmn",


### PR DESCRIPTION
## Problem

On the OpenAI-compatible server (`koko openai`), British English voices (`bf_*`, `bm_*`) return near-empty audio, while American voices work normally. Fixes #137.

## Cause

`get_language_code()` derives the phonemizer language from the voice-name prefix and maps `b` → `"en-gb"`. **`"en-gb"` is not a valid espeak-ng voice identifier**, so phonemization returns empty phonemes and the model produces near-empty audio. Reproduced with the CLI on identical text:

- `koko -l en-us       -s bf_emma …` → ~1.01 MB WAV (works)
- `koko -l en-gb       -s bf_emma …` → ~62 KB  WAV (broken — invalid id)
- `koko -l en-gb-x-rp  -s bf_emma …` → ~1.02 MB WAV (works — valid RP British id)

American voices map to `en-us` and are unaffected.

## Fix

Map British voices to `en-gb-x-rp`, the RP British identifier espeak-ng actually recognizes, so they get correct British phonemization (rather than empty output). One-line change in `get_language_code()`.

## Test

With the patch, same text via the HTTP endpoint:

| voice | before | after |
|-------|--------|-------|
| `bf_emma` | ~31 KB | ~509 KB |
| `bm_george` | ~31 KB | ~585 KB |
| `af_sarah` (control) | ~550 KB | ~550 KB |
